### PR TITLE
ATOR-15 Fix: update commit hash to build on

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 # Sets which version of ator-protocol to use.
 # See https://github.com/ATOR-Development/ator-protocol/tags for available tags.
-ARG ATOR_VER="e45103d7ffa0e7323c4b66be7179c8d66ebed92c"
+ARG ATOR_VER="9509c943ff259455f321dfa32d7ba82273c5c074"
 ARG ATOR_REPO="https://github.com/ATOR-Development/ator-protocol.git"
 
 # Sets ator-protocol ports for build time


### PR DESCRIPTION
Previous commit hash was removed from git tree after PR squash