### PR TITLE
ATOR-148 Expose reachability self-test on metrics endpoint

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -15,8 +15,8 @@ Depends: ${shlibs:Depends}, adduser, ${misc:Depends}, lsb-base
 Pre-Depends: ${misc:Pre-Depends}
 Conflicts: libssl0.9.8 (<< 0.9.8g-9)
 Breaks: ${runit:Breaks}
-Recommends: logrotate, anon-geoipdb, torsocks
-Suggests: mixmaster, torbrowser-launcher, socat, apparmor-utils, nyx, obfs4proxy
+Recommends: logrotate, anon-geoipdb
+Suggests: mixmaster, socat, apparmor-utils, nyx, obfs4proxy
 Description: anonymizing overlay network for TCP
  Tor is a connection-based low-latency anonymous communication system.
  .

--- a/src/feature/relay/relay_metrics.h
+++ b/src/feature/relay/relay_metrics.h
@@ -57,6 +57,8 @@ typedef enum {
   RELAY_METRICS_NUM_INTRO1_CELLS,
   /** Number of times we received a REND1 cell */
   RELAY_METRICS_NUM_REND1_CELLS,
+  /** Reachability self-test gauges. */
+  RELAY_METRICS_REACHABILITY_GAUGES,
 } relay_metrics_key_t;
 
 /** The metadata of a relay metric. */

--- a/src/feature/relay/selftest.c
+++ b/src/feature/relay/selftest.c
@@ -130,6 +130,24 @@ router_orport_seems_reachable(const or_options_t *options,
   return true;
 }
 
+/**
+ * Return true if performed reachability self-test annotated orport reachable.
+ * Works only for AF_INET and AF_INET6 families.
+*/
+int
+router_orport_reachable(int family)
+{
+  if (family == AF_INET && can_reach_or_port_ipv4) {
+    return true;
+  }
+
+  if (family == AF_INET6 && can_reach_or_port_ipv6) {
+    return true;
+  }
+
+  return false;
+}
+
 /** Relay DirPorts are no longer used (though authorities are). In either case,
  * reachability self test is done anymore, since network re-entry towards an
  * authority DirPort is not allowed. Thus, consider it always reachable. */

--- a/src/feature/relay/selftest.h
+++ b/src/feature/relay/selftest.h
@@ -20,6 +20,7 @@ struct or_options_t;
 int router_orport_seems_reachable(
                                          const struct or_options_t *options,
                                          int family);
+int router_orport_reachable(int family);
 int router_dirport_seems_reachable(
                                          const struct or_options_t *options);
 


### PR DESCRIPTION
To test reachability self-test:

`anonrc` file:
```
MetricsPort 127.0.0.1:8080
MetricsPortPolicy accept 127.0.0.1
```

run:
```
curl 127.0.0.1:8080/metrics | grep tor_relay_reachability
```