### PR TITLE
ATOR-237 - Rebranding logs

### DIFF
--- a/debian/anon.postinst
+++ b/debian/anon.postinst
@@ -49,7 +49,7 @@ chmod 02750 /var/log/anon
 
 
 anon_error_init() {
-	echo "Tor was unable to start due to configuration errors.";
+	echo "Anon was unable to start due to configuration errors.";
 	echo "Please fix them and manually restart the anon daemon using";
 	echo " ´service start anon";
 }

--- a/scripts/ci/ci-driver.sh
+++ b/scripts/ci/ci-driver.sh
@@ -316,7 +316,7 @@ if [[ ! -d "$CI_SRCDIR" ]] ; then
     die "CI_SRCDIR=${CI_SRCDIR} is not a directory"
 fi
 if [[ ! -f "$CI_SRCDIR/src/core/or/or.h" ]] ; then
-    die "CI_SRCDIR=${CI_SRCDIR} does not look like a Tor directory."
+    die "CI_SRCDIR=${CI_SRCDIR} does not look like a Anon directory."
 fi
 
 # Make CI_SRCDIR absolute.
@@ -350,7 +350,7 @@ else
         die "Build directory ${CI_BUILDDIR} did not exist!"
     fi
     if [[ ! -f "${CI_BUILDDIR}/config.log" ]]; then
-        die "Tor was not configured in ${CI_BUILDDIR}!"
+        die "Anon was not configured in ${CI_BUILDDIR}!"
     fi
 
     cp config.log "${CI_SRCDIR}"/artifacts
@@ -406,7 +406,7 @@ if [[ "${DOXYGEN}" = 'yes' ]]; then
             FAILED_TESTS="${FAILED_TESTS} doxygen"
         fi
     else
-        skipping "make doxygen: doxygen is broken for Tor < 0.4.3"
+        skipping "make doxygen: doxygen is broken for Anon < 0.4.3"
     fi
     end_section Doxygen
 fi

--- a/scripts/coccinelle/check_cocci_parse.sh
+++ b/scripts/coccinelle/check_cocci_parse.sh
@@ -62,7 +62,7 @@ SPATCH_V=$(spatch --version | head -1 | \
                sed 's/spatch version \([0-9][^ ]*\).*/\1/')
 
 if ! version_ge "$SPATCH_V" "$MIN_SPATCH_V" ; then
-    echo "Tor requires coccinelle spatch >= $MIN_SPATCH_V to check $PURPOSE."
+    echo "Anon requires coccinelle spatch >= $MIN_SPATCH_V to check $PURPOSE."
     echo "But you have $SPATCH_V. Please install a newer version."
     exit "$exitcode"
 fi

--- a/scripts/maint/code-format.sh
+++ b/scripts/maint/code-format.sh
@@ -45,7 +45,7 @@ function usage() {
     echo "    -c: check whether files are correctly formatted"
     echo "    -d: print a diff for the changes that would be applied"
     echo "    -i: change files in-place"
-    echo "    -a: run over all the C files in Tor"
+    echo "    -a: run over all the C files in Anon"
     echo "    -v: verbose mode"
     echo "    -g: look at the files that have changed in git."
     echo "    -G: look at the files that are staged for the git commit."

--- a/src/app/config/config.c
+++ b/src/app/config/config.c
@@ -3414,7 +3414,7 @@ options_validate_cb(const void *old_options_, void *options_, char **msg)
 
   if (options->ExcludeNodes && options->StrictNodes) {
     COMPLAIN("You have asked to exclude certain relays from all positions "
-             "in your circuits. Expect hidden services and other Tor "
+             "in your circuits. Expect hidden services and other Anon "
              "features to be broken in unpredictable ways.");
   }
 
@@ -4195,7 +4195,7 @@ options_check_transition_cb(const void *old_,
     return 0;
 
 #define BAD_CHANGE_TO(opt, how) do {                                    \
-    *msg = tor_strdup("While Tor is running"how", changing " #opt       \
+    *msg = tor_strdup("While Anon is running"how", changing " #opt       \
                       " is not allowed");                               \
     return -1;                                                          \
   } while (0)

--- a/src/app/config/config.c
+++ b/src/app/config/config.c
@@ -1263,9 +1263,9 @@ validate_dir_servers(const or_options_t *options,
              "You have used DirAuthority or AlternateDirAuthority to "
              "specify alternate directory authorities in "
              "your configuration. This is potentially dangerous: it can "
-             "make you look different from all other Tor users, and hurt "
+             "make you look different from all other Anon users, and hurt "
              "your anonymity. Even if you've specified the same "
-             "authorities as Tor uses by default, the defaults could "
+             "authorities as Anon uses by default, the defaults could "
              "change in the future. Be sure you know what you're doing.");
   }
 
@@ -1671,7 +1671,7 @@ options_start_listener_transaction(const or_options_t *old_options,
   }
   if (options->DisableNetwork) {
     /* Aggressively close non-controller stuff, NOW */
-    log_notice(LD_NET, "DisableNetwork is set. Tor will not make or accept "
+    log_notice(LD_NET, "DisableNetwork is set. Anon will not make or accept "
                "non-control network connections. Shutting down all existing "
                "connections.");
     connection_mark_all_noncontrol_connections();
@@ -2117,7 +2117,7 @@ options_act,(const or_options_t *old_options))
   }
 
   if (hs_service_non_anonymous_mode_enabled(options)) {
-    log_warn(LD_GENERAL, "This copy of Tor was compiled or configured to run "
+    log_warn(LD_GENERAL, "This copy of Anon was compiled or configured to run "
              "in a non-anonymous mode. It will provide NO ANONYMITY.");
   }
 
@@ -3342,7 +3342,7 @@ options_validate_cb(const void *old_options_, void *options_, char **msg)
     log_warn(LD_CONFIG,
         "SocksPort, TransPort, NATDPort, DNSPort, and ORPort are all "
         "undefined, and there aren't any hidden services configured.  "
-        "Tor will still run, but probably won't do anything.");
+        "Anon will still run, but probably won't do anything.");
 
   options->TransProxyType_parsed = TPT_DEFAULT;
 #ifdef USE_TRANSPARENT
@@ -3599,7 +3599,7 @@ options_validate_cb(const void *old_options_, void *options_, char **msg)
       !hs_service_allow_non_anonymous_connection(options)) {
     log_warn(LD_CONFIG,
              "UseEntryGuards is disabled, but you have configured one or more "
-             "hidden services on this Tor instance.  Your hidden services "
+             "hidden services on this Anon instance.  Your hidden services "
              "will be very easy to locate using a well-known attack -- see "
              "https://freehaven.net/anonbib/#hs-attack06 for details.");
   }
@@ -3643,7 +3643,7 @@ options_validate_cb(const void *old_options_, void *options_, char **msg)
     log_warn(LD_CONFIG,
              "HiddenServiceNonAnonymousMode is set. Every hidden service on "
              "this tor instance is NON-ANONYMOUS. If "
-             "the HiddenServiceNonAnonymousMode option is changed, Tor will "
+             "the HiddenServiceNonAnonymousMode option is changed, Anon will "
              "refuse to launch hidden services from the same directories, to "
              "protect your anonymity against config errors. This setting is "
              "for experimental use only.");
@@ -3880,8 +3880,8 @@ options_validate_cb(const void *old_options_, void *options_, char **msg)
       !options->CookieAuthentication) {
     log_warn(LD_CONFIG, "Control%s is %s, but no authentication method "
              "has been configured.  This means that any program on your "
-             "computer can reconfigure your Tor.  That's bad!  You should "
-             "upgrade your Tor controller as soon as possible.",
+             "computer can reconfigure your Anon.  That's bad!  You should "
+             "upgrade your Anon controller as soon as possible.",
              options->ControlPort_set ? "Port" : "Socket",
              options->ControlPort_set ? "open" : "world writable");
   }
@@ -4058,9 +4058,9 @@ options_validate_cb(const void *old_options_, void *options_, char **msg)
 
   if (options->TestingTorNetwork) {
     log_warn(LD_CONFIG, "TestingTorNetwork is set. This will make your node "
-                        "almost unusable in the public Tor network, and is "
+                        "almost unusable in the public Anon network, and is "
                         "therefore only advised if you are building a "
-                        "testing Tor network!");
+                        "testing Anon network!");
   }
 
   if (options_validate_scheduler(options, msg) < 0) {
@@ -4515,7 +4515,7 @@ options_init_from_torrc(int argc, char **argv)
   if (config_line_find(cmdline_only_options, "--version")) {
     printf("Anon version %s.\n",get_version());
 #ifdef ENABLE_GPL
-    printf("This build of Tor is covered by the GNU General Public License "
+    printf("This build of Anon is covered by the GNU General Public License "
             "(https://www.gnu.org/licenses/gpl-3.0.en.html)\n");
 #endif
     printf("Anon is running on %s with Libevent %s, "
@@ -5941,9 +5941,9 @@ warn_nonlocal_controller_ports(smartlist_t *ports, unsigned forbid_nonlocal)
                  "You have a ControlPort set to accept "
                  "unauthenticated connections from a non-local address.  "
                  "This means that programs not running on your computer "
-                 "can reconfigure your Tor, without even having to guess a "
+                 "can reconfigure your Anon, without even having to guess a "
                  "password.  That's so bad that I'm closing your ControlPort "
-                 "for you.  If you need to control your Tor remotely, try "
+                 "for you.  If you need to control your Anon remotely, try "
                  "enabling authentication and using a tool like stunnel or "
                  "ssh to encrypt remote access.");
         warned = 1;
@@ -5953,7 +5953,7 @@ warn_nonlocal_controller_ports(smartlist_t *ports, unsigned forbid_nonlocal)
         log_warn(LD_CONFIG, "You have a ControlPort set to accept "
                  "connections from a non-local address.  This means that "
                  "programs not running on your computer can reconfigure your "
-                 "Tor.  That's pretty bad, since the controller "
+                 "Anon.  That's pretty bad, since the controller "
                  "protocol isn't encrypted!  Maybe you should just listen on "
                  "127.0.0.1 and use a tool like stunnel or ssh to encrypt "
                  "remote connections to your control port.");

--- a/src/app/config/config.c
+++ b/src/app/config/config.c
@@ -3241,7 +3241,7 @@ options_validate_single_onion(or_options_t *options, char **msg)
                                options->DNSPort_set ||
                                options->HTTPTunnelPort_set);
   if (hs_service_non_anonymous_mode_enabled(options) && client_port_set) {
-    REJECT("HiddenServiceNonAnonymousMode is incompatible with using Tor as "
+    REJECT("HiddenServiceNonAnonymousMode is incompatible with using Anon as "
            "an anonymous client. Please set Socks/Trans/NATD/DNSPort to 0, or "
            "revert HiddenServiceNonAnonymousMode to 0.");
   }
@@ -3979,7 +3979,7 @@ options_validate_cb(const void *old_options_, void *options_, char **msg)
     if (!config_is_same(get_options_mgr(),options,                      \
                         dflt_options,#arg)) {                           \
       or_options_free(dflt_options);                                    \
-      REJECT(#arg " may only be changed in testing Tor "                \
+      REJECT(#arg " may only be changed in testing Anon "                \
              "networks!");                                              \
     }                                                                   \
   STMT_END
@@ -4047,13 +4047,13 @@ options_validate_cb(const void *old_options_, void *options_, char **msg)
   if (options->TestingEnableConnBwEvent &&
       !options->TestingTorNetwork && !options->UsingTestNetworkDefaults_) {
     REJECT("TestingEnableConnBwEvent may only be changed in testing "
-           "Tor networks!");
+           "Anon networks!");
   }
 
   if (options->TestingEnableCellStatsEvent &&
       !options->TestingTorNetwork && !options->UsingTestNetworkDefaults_) {
     REJECT("TestingEnableCellStatsEvent may only be changed in testing "
-           "Tor networks!");
+           "Anon networks!");
   }
 
   if (options->TestingTorNetwork) {

--- a/src/app/config/resolve_addr.c
+++ b/src/app/config/resolve_addr.c
@@ -209,7 +209,7 @@ address_can_be_used(const tor_addr_t *addr, const or_options_t *options,
    * directory authorities. */
   if (using_default_dir_authorities(options)) {
     log_fn(warn_severity, LD_CONFIG,
-           "Address '%s' is a private IP address. Tor relays that use "
+           "Address '%s' is a private IP address. Anon relays that use "
            "the default DirAuthorities must have public IP addresses.",
            fmt_addr(addr));
     return ERR_DEFAULT_DIRAUTH;
@@ -346,7 +346,7 @@ get_address_from_config(const or_options_t *options, int warn_severity,
     if (ret == ERR_ADDRESS_IS_INTERNAL) {
       static bool logged_once = false;
       if (!logged_once) {
-        log_warn(LD_CONFIG, "Address set with an internal address. Tor will "
+        log_warn(LD_CONFIG, "Address set with an internal address. Anon will "
                             "not work unless custom directory authorities "
                             "are defined (AlternateDirAuthority). It is also "
                             "possible to use an internal address if "

--- a/src/app/config/statefile.c
+++ b/src/app/config/statefile.c
@@ -386,7 +386,7 @@ or_state_save_broken(char *fname)
     }
   } else {
     log_warn(LD_BUG, "Unable to parse state in \"%s\". Moving it aside "
-             "to \"%s\".  This could be a bug in Tor; please tell "
+             "to \"%s\".  This could be a bug in Anon; please tell "
              "the developers.", fname, fname2);
     if (tor_rename(fname, fname2) < 0) {//XXXX sandbox prohibits
       log_warn(LD_BUG, "Weirdly, I couldn't even move the state aside. The "
@@ -462,7 +462,7 @@ or_state_load(void)
 
   if (badstate && !contents) {
     log_warn(LD_BUG, "Uh oh.  We couldn't even validate our own default state."
-             " This is a bug in Tor.");
+             " This is a bug in Anon.");
     goto done;
   } else if (badstate && contents) {
     or_state_save_broken(fname);
@@ -583,12 +583,12 @@ or_state_save(time_t now)
   global_state->LastWritten = now;
 
   tor_free(global_state->TorVersion);
-  tor_asprintf(&global_state->TorVersion, "Tor %s", get_version());
+  tor_asprintf(&global_state->TorVersion, "Anon %s", get_version());
 
   state = config_dump(get_state_mgr(), NULL, global_state, 1, 0);
   format_local_iso_time(tbuf, now);
   tor_asprintf(&contents,
-               "# Tor state file last generated on %s local time\n"
+               "# Anon state file last generated on %s local time\n"
                "# Other times below are in UTC\n"
                "# You *do not* need to edit this file.\n\n%s",
                tbuf, state);

--- a/src/app/config/statefile.c
+++ b/src/app/config/statefile.c
@@ -583,7 +583,7 @@ or_state_save(time_t now)
   global_state->LastWritten = now;
 
   tor_free(global_state->TorVersion);
-  tor_asprintf(&global_state->TorVersion, "Anon %s", get_version());
+  tor_asprintf(&global_state->TorVersion, "Tor %s", get_version());
 
   state = config_dump(get_state_mgr(), NULL, global_state, 1, 0);
   format_local_iso_time(tbuf, now);

--- a/src/app/main/ntmain.c
+++ b/src/app/main/ntmain.c
@@ -626,8 +626,8 @@ nt_service_install(int argc, char **argv)
    * situation. */
   if (using_default_torrc)
     printf("IMPORTANT NOTE:\n"
-        "    The Tor service will run under the account \"%s\".  This means\n"
-        "    that Tor will look for its configuration file under that\n"
+        "    The Anon service will run under the account \"%s\".  This means\n"
+        "    that Anon will look for its configuration file under that\n"
         "    account's Application Data directory, which is probably not\n"
         "    the same as yours.\n", user_acct?user_acct:"<local system>");
 

--- a/src/core/mainloop/connection.c
+++ b/src/core/mainloop/connection.c
@@ -1348,7 +1348,7 @@ check_location_for_unix_socket(const or_options_t *options, const char *path,
   p = tor_strdup(path);
   cpd_check_t flags = CPD_CHECK_MODE_ONLY;
   if (get_parent_directory(p)<0 || p[0] != '/') {
-    log_warn(LD_GENERAL, "Bad unix socket address '%s'.  Tor does not support "
+    log_warn(LD_GENERAL, "Bad unix socket address '%s'.  Anon does not support "
              "relative paths for unix sockets.", path);
     goto done;
   }
@@ -1371,10 +1371,10 @@ check_location_for_unix_socket(const or_options_t *options, const char *path,
     char *escpath, *escdir;
     escpath = esc_for_log(path);
     escdir = esc_for_log(p);
-    log_warn(LD_GENERAL, "Before Tor can create a %s in %s, the directory "
+    log_warn(LD_GENERAL, "Before Anon can create a %s in %s, the directory "
              "%s needs to exist, and to be accessible only by the user%s "
-             "account that is running Tor.  (On some Unix systems, anybody "
-             "who can list a socket can connect to it, so Tor is being "
+             "account that is running Anon.  (On some Unix systems, anybody "
+             "who can list a socket can connect to it, so Anon is being "
              "careful.)",
              unix_socket_purpose_to_string(purpose), escpath, escdir,
              port->is_group_writable ? " and group" : "");
@@ -1572,7 +1572,7 @@ connection_listener_new(const struct sockaddr *listensockaddr,
       const char *helpfulhint = "";
       int e = tor_socket_errno(s);
       if (ERRNO_IS_EADDRINUSE(e)) {
-        helpfulhint = ". Is Tor already running?";
+        helpfulhint = ". Is Anon already running?";
         if (addr_in_use)
           *addr_in_use = 1;
       }
@@ -2244,9 +2244,9 @@ connection_connect_sockaddr,(connection_t *conn,
   if (bindaddr && try_ip_bind_address_no_port &&
       setsockopt(s, SOL_IP, IP_BIND_ADDRESS_NO_PORT, &(int){1}, sizeof(int))) {
     if (errno == EINVAL) {
-      log_notice(LD_NET, "Tor was built with support for "
+      log_notice(LD_NET, "Anon was built with support for "
                          "IP_BIND_ADDRESS_NO_PORT, but the current kernel "
-                         "doesn't support it. This might cause Tor to run out "
+                         "doesn't support it. This might cause Anon to run out "
                          "of ephemeral ports more quickly.");
       try_ip_bind_address_no_port = 0;
     } else {
@@ -5973,7 +5973,7 @@ clock_skew_warning, (const connection_t *conn, long apparent_skew, int trusted,
   log_fn(trusted ? LOG_WARN : LOG_INFO, domain,
          "Received %s with skewed time (%s): "
          "It seems that our clock is %s by %s, or that theirs is %s%s. "
-         "Tor requires an accurate clock to work: please check your time, "
+         "Anon requires an accurate clock to work: please check your time, "
          "timezone, and date settings.", received, ext_source,
          apparent_skew > 0 ? "ahead" : "behind", dbuf,
          apparent_skew > 0 ? "behind" : "ahead",

--- a/src/core/mainloop/mainloop.c
+++ b/src/core/mainloop/mainloop.c
@@ -1235,7 +1235,7 @@ run_connection_housekeeping(int i, time_t now)
     if (conn->state == OR_CONN_STATE_CONNECTING)
       connection_or_connect_failed(TO_OR_CONN(conn),
                                    END_OR_CONN_REASON_TIMEOUT,
-                                   "Tor gave up on the connection");
+                                   "Anon gave up on the connection");
     connection_or_close_normally(TO_OR_CONN(conn), 1);
   } else if (!connection_state_is_open(conn)) {
     if (past_keepalive) {

--- a/src/core/mainloop/netstatus.c
+++ b/src/core/mainloop/netstatus.c
@@ -65,7 +65,7 @@ note_user_activity(time_t now)
   last_user_activity_seen = MAX(now, last_user_activity_seen);
 
   if (! participating_on_network) {
-    log_notice(LD_GENERAL, "Tor is no longer dormant.");
+    log_notice(LD_GENERAL, "Anon is no longer dormant.");
     set_network_participation(true);
     schedule_rescan_periodic_events();
   }

--- a/src/core/or/circuitbuild.c
+++ b/src/core/or/circuitbuild.c
@@ -1126,7 +1126,7 @@ circuit_build_no_more_hops(origin_circuit_t *circ)
     note_that_we_completed_a_circuit();
     /* FFFF Log a count of known routers here */
     log_info(LD_GENERAL,
-             "Tor has successfully opened a circuit. "
+             "Anon has successfully opened a circuit. "
              "Looks like client functionality is working.");
     control_event_bootstrap(BOOTSTRAP_STATUS_DONE, 0);
     control_event_client_status(LOG_NOTICE, "CIRCUIT_ESTABLISHED");
@@ -1238,7 +1238,7 @@ circuit_note_clock_jumped(int64_t seconds_elapsed, bool was_idle)
 {
   int severity = server_mode(get_options()) ? LOG_WARN : LOG_NOTICE;
   if (was_idle) {
-    tor_log(severity, LD_GENERAL, "Tor has been idle for %"PRId64
+    tor_log(severity, LD_GENERAL, "Anon has been idle for %"PRId64
             " seconds; assuming established circuits no longer work.",
             (seconds_elapsed));
   } else {
@@ -1930,7 +1930,7 @@ pick_restricted_middle_node(router_crn_flags_t flags,
     log_fn_ratelim(&pinned_notice_limit, LOG_NOTICE, LD_CIRC,
             "Your _HSLayer%dNodes setting has resulted "
             "in %d total nodes. This is a lot of nodes. "
-            "You may want to consider using a Tor controller "
+            "You may want to consider using a Anon controller "
             "to select and update a smaller set of nodes instead.",
             position_hint, smartlist_len(allowlisted_live_middles));
 
@@ -2060,7 +2060,7 @@ warn_if_last_router_excluded(origin_circuit_t *circ,
     } else {
       log_warn(LD_CIRC, "Using %s '%s' which is listed in "
                "ExcludeNodes%s, because no better options were available. To "
-               "prevent this (and possibly break your Tor functionality), "
+               "prevent this (and possibly break your Anon functionality), "
                "set the StrictNodes configuration option. "
                "(Circuit purpose: %s)",
                description, extend_info_describe(exit_ei),

--- a/src/core/or/circuitstats.c
+++ b/src/core/or/circuitstats.c
@@ -440,7 +440,7 @@ circuit_build_times_new_consensus_params(circuit_build_times_t *cbt,
       if (num != cbt->liveness.num_recent_circs) {
         int8_t *recent_circs;
         if (cbt->liveness.num_recent_circs > 0) {
-          log_notice(LD_CIRC, "The Tor Directory Consensus has changed how "
+          log_notice(LD_CIRC, "The Anon Directory Consensus has changed how "
                      "many circuits we must track to detect network failures "
                      "from %d to %d.", cbt->liveness.num_recent_circs, num);
         } else {
@@ -966,7 +966,7 @@ circuit_build_times_shuffle_and_store_array(circuit_build_times_t *cbt,
 {
   uint32_t n = num_times;
   if (num_times > CBT_NCIRCUITS_TO_OBSERVE) {
-    log_notice(LD_CIRC, "The number of circuit times that this Tor version "
+    log_notice(LD_CIRC, "The number of circuit times that this Anon version "
                "uses to calculate build times is less than the number stored "
                "in your state file. Decreasing the circuit time history from "
                "%lu to %d.", (unsigned long)num_times,
@@ -1372,7 +1372,7 @@ circuit_build_times_network_is_live(circuit_build_times_t *cbt)
   if (cbt->liveness.nonlive_timeouts > 0) {
     time_t time_since_live = now - cbt->liveness.network_last_live;
     log_notice(LD_CIRC,
-               "Tor now sees network activity. Restoring circuit build "
+               "Anon now sees network activity. Restoring circuit build "
                "timeout recording. Network was down for %d seconds "
                "during %d circuit attempts.",
                (int)time_since_live,
@@ -1514,7 +1514,7 @@ circuit_build_times_network_close(circuit_build_times_t *cbt,
     cbt->liveness.nonlive_timeouts++;
     if (cbt->liveness.nonlive_timeouts == 1) {
       log_notice(LD_CIRC,
-                 "Tor has not observed any network activity for the past %d "
+                 "Anon has not observed any network activity for the past %d "
                  "seconds. Disabling circuit build timeout recording.",
                  (int)(now - cbt->liveness.network_last_live));
 

--- a/src/core/or/circuituse.c
+++ b/src/core/or/circuituse.c
@@ -2348,7 +2348,7 @@ circuit_get_open_circ_or_launch(entry_connection_t *conn,
                                               conn->socks_request->port,
                                               need_uptime)) {
         log_notice(LD_APP,
-                   "No Tor server allows exit to %s:%d. Rejecting.",
+                   "No Anon server allows exit to %s:%d. Rejecting.",
                    safe_str_client(conn->socks_request->address),
                    conn->socks_request->port);
         return -1;

--- a/src/core/or/command.c
+++ b/src/core/or/command.c
@@ -418,7 +418,7 @@ command_process_created_cell(cell_t *cell, channel_t *chan)
 
   if (circ->n_circ_id != cell->circ_id || circ->n_chan != chan) {
     log_fn(LOG_PROTOCOL_WARN,LD_PROTOCOL,
-           "got created cell from Tor client? Closing.");
+           "got created cell from Anon client? Closing.");
     circuit_mark_for_close(circ, END_CIRC_REASON_TORPROTOCOL);
     return;
   }

--- a/src/core/or/connection_edge.c
+++ b/src/core/or/connection_edge.c
@@ -1823,7 +1823,7 @@ connection_ap_handshake_rewrite(entry_connection_t *conn,
   if (!strcmpend(socks->address, ".exit")) {
     static ratelim_t exit_warning_limit = RATELIM_INIT(60*15);
     log_fn_ratelim(&exit_warning_limit, LOG_WARN, LD_APP,
-                   "The  \".exit\" notation is disabled in Tor due to "
+                   "The  \".exit\" notation is disabled in Anon due to "
                    "security risks.");
     control_event_client_status(LOG_WARN, "SOCKS_BAD_HOSTNAME HOSTNAME=%s",
                                 escaped(socks->address));
@@ -2487,8 +2487,8 @@ connection_ap_handshake_rewrite_and_attach(entry_connection_t *conn,
               nodelist_reentry_contains(&addr, socks->port)) {
             log_warn(LD_APP, "Not attempting connection to %s:%d because "
                      "the network would reject it. Are you trying to send "
-                     "Tor traffic over Tor? This traffic can be harmful to "
-                     "the Tor network. If you really need it, try using "
+                     "Anon traffic over Anon? This traffic can be harmful to "
+                     "the Anon network. If you really need it, try using "
                      "a bridge as a workaround.",
                      safe_str_client(socks->address), socks->port);
             connection_mark_unattached_ap(conn, END_STREAM_REASON_TORPROTOCOL);

--- a/src/core/or/connection_or.c
+++ b/src/core/or/connection_or.c
@@ -2009,7 +2009,7 @@ connection_or_client_learned_peer_id(or_connection_t *conn,
           /* we expect a small number of fallbacks to change from their
            * hard-coded fingerprints over the life of a release */
           severity = LOG_INFO;
-          extra_log = " Tor will try a different fallback.";
+          extra_log = " Anon will try a different fallback.";
         } else {
           /* it's a bridge, it's either a misconfiguration, or unexpected */
           severity = LOG_WARN;

--- a/src/core/or/policies.c
+++ b/src/core/or/policies.c
@@ -305,7 +305,7 @@ parse_reachable_addresses(void)
   if (!server_mode(options)) {
     if (policy_is_reject_star(reachable_or_addr_policy, AF_UNSPEC, 0)
         || policy_is_reject_star(reachable_dir_addr_policy, AF_UNSPEC,0)) {
-      log_warn(LD_CONFIG, "Tor cannot connect to the Internet if "
+      log_warn(LD_CONFIG, "Anon cannot connect to the Internet if "
                "ReachableAddresses, ReachableORAddresses, or "
                "ReachableDirAddresses reject all addresses. Please accept "
                "some addresses in these options.");
@@ -315,7 +315,7 @@ parse_reachable_addresses(void)
           log_warn(LD_CONFIG, "You have set ClientUseIPv4 1, but "
                    "ReachableAddresses, ReachableORAddresses, or "
                    "ReachableDirAddresses reject all IPv4 addresses. "
-                   "Tor will not connect using IPv4.");
+                   "Anon will not connect using IPv4.");
     } else if (reachable_addr_use_ipv6(options)
        && (policy_is_reject_star(reachable_or_addr_policy, AF_INET6, 0)
          || policy_is_reject_star(reachable_dir_addr_policy, AF_INET6, 0))) {
@@ -323,7 +323,7 @@ parse_reachable_addresses(void)
                    "(or UseBridges 1), but "
                    "ReachableAddresses, ReachableORAddresses, or "
                    "ReachableDirAddresses reject all IPv6 addresses. "
-                   "Tor will not connect using IPv6.");
+                   "Anon will not connect using IPv6.");
     }
   }
 
@@ -1166,7 +1166,7 @@ validate_addr_policies(const or_options_t *options, char **msg)
   if (public_server_mode(options) && !warned_about_nonexit &&
       policy_using_default_exit_options(options)) {
     warned_about_nonexit = 1;
-    log_notice(LD_CONFIG, "By default, Tor does not run as an exit relay. "
+    log_notice(LD_CONFIG, "By default, Anon does not run as an exit relay. "
                "If you want to be an exit relay, "
                "set ExitRelay to 1. To suppress this message in the future, "
                "set ExitRelay to 0.");

--- a/src/core/or/protover.c
+++ b/src/core/or/protover.c
@@ -216,7 +216,7 @@ parse_single_entry(const char *s, const char *end_of_entry)
   if (equals - s > (int)MAX_PROTOCOL_NAME_LENGTH) {
     log_warn(LD_NET, "When parsing a protocol entry, I got a very large "
              "protocol name. This is possibly an attack or a bug, unless "
-             "the Tor network truly supports protocol names larger than "
+             "the Anon network truly supports protocol names larger than "
              "%ud characters. The offending string was: %s",
              MAX_PROTOCOL_NAME_LENGTH, escaped(out->name));
     goto error;

--- a/src/core/or/reasons.c
+++ b/src/core/or/reasons.c
@@ -80,7 +80,7 @@ stream_end_reason_to_string(int reason)
     case END_STREAM_REASON_INTERNAL:       return "internal error at server";
     case END_STREAM_REASON_RESOURCELIMIT:  return "server out of resources";
     case END_STREAM_REASON_CONNRESET:      return "connection reset";
-    case END_STREAM_REASON_TORPROTOCOL:    return "Tor protocol error";
+    case END_STREAM_REASON_TORPROTOCOL:    return "Anon protocol error";
     case END_STREAM_REASON_NOTDIRECTORY:   return "not a directory";
     default:
       log_fn(LOG_PROTOCOL_WARN, LD_PROTOCOL,

--- a/src/core/or/relay.c
+++ b/src/core/or/relay.c
@@ -2055,7 +2055,7 @@ handle_relay_cell_command(cell_t *cell, circuit_t *circ,
   }
   log_fn(LOG_PROTOCOL_WARN, LD_PROTOCOL,
          "Received unknown relay command %d. Perhaps the other side is using "
-         "a newer version of Tor? Dropping.",
+         "a newer version of Anon? Dropping.",
          rh->command);
   return 0; /* for forward compatibility, don't kill the circuit */
 }

--- a/src/core/or/scheduler.c
+++ b/src/core/or/scheduler.c
@@ -296,9 +296,9 @@ select_scheduler(void)
 
  end:
   if (new_scheduler == NULL) {
-    log_err(LD_SCHED, "Tor was unable to select a scheduler type. Please "
+    log_err(LD_SCHED, "Anon was unable to select a scheduler type. Please "
                       "make sure Schedulers is correctly configured with "
-                      "what Tor does support.");
+                      "what Anon does support.");
     /* We weren't able to choose a scheduler which means that none of the ones
      * set in Schedulers are supported or usable. We will respect the user
      * wishes of using what it has been configured and don't do a sneaky

--- a/src/core/or/status.c
+++ b/src/core/or/status.c
@@ -205,7 +205,7 @@ log_heartbeat(time_t now)
   bw_rcvd = bytes_to_usage(get_bytes_read());
   bw_sent = bytes_to_usage(get_bytes_written());
 
-  log_fn(LOG_NOTICE, LD_HEARTBEAT, "Heartbeat: Tor's uptime is %s, with %d "
+  log_fn(LOG_NOTICE, LD_HEARTBEAT, "Heartbeat: Anon's uptime is %s, with %d "
          "circuits open. I've sent %s and received %s. I've received %u "
          "connections on IPv4 and %u on IPv6. I've made %u connections "
          "with IPv4 and %u with IPv6.%s",

--- a/src/core/proto/proto_socks.c
+++ b/src/core/proto/proto_socks.c
@@ -64,7 +64,7 @@ log_unsafe_socks_warning(int socks_protocol, const char *address,
   if (safe_socks) {
     log_fn_ratelim(&socks_ratelim, LOG_WARN, LD_APP,
              "Your application (using socks%d to port %d) is giving "
-             "Tor only an IP address. Applications that do DNS resolves "
+             "Anon only an IP address. Applications that do DNS resolves "
              "themselves may leak information. Consider using Socks4A "
              "(e.g. via privoxy or socat) instead. For more information, "
              "please see https://2019.www.torproject.org/docs/faq.html.en"
@@ -253,13 +253,13 @@ process_socks4_request(const socks_request_t *req, int is_socks4a,
     if (log_sockstype)
       log_notice(LD_APP,
                  "Your application (using socks4a to port %d) instructed "
-                 "Tor to take care of the DNS resolution itself if "
+                 "Anon to take care of the DNS resolution itself if "
                  "necessary. This is good.", req->port);
   }
 
   if (!string_is_valid_dest(req->address)) {
     log_warn(LD_PROTOCOL,
-             "Your application (using socks4 to port %d) gave Tor "
+             "Your application (using socks4 to port %d) gave Anon "
              "a malformed hostname: %s. Rejecting the connection.",
              req->port, escaped_safe_str_client(req->address));
      return SOCKS_RESULT_INVALID;
@@ -646,7 +646,7 @@ process_socks5_client_request(socks_request_t *req,
     socks_request_set_socks5_error(req, SOCKS5_GENERAL_ERROR);
 
     log_warn(LD_PROTOCOL,
-             "Your application (using socks5 to port %d) gave Tor "
+             "Your application (using socks5 to port %d) gave Anon "
              "a malformed hostname: %s. Rejecting the connection.",
              req->port, escaped_safe_str_client(req->address));
 
@@ -669,7 +669,7 @@ process_socks5_client_request(socks_request_t *req,
   if (log_sockstype)
     log_notice(LD_APP,
               "Your application (using socks5 to port %d) instructed "
-              "Tor to take care of the DNS resolution itself if "
+              "Anon to take care of the DNS resolution itself if "
               "necessary. This is good.", req->port);
 
   end:

--- a/src/feature/client/circpathbias.c
+++ b/src/feature/client/circpathbias.c
@@ -1370,7 +1370,7 @@ pathbias_measure_use_rate(entry_guard_t *guard)
           log_warn(LD_CIRC,
                  "Guard %s is failing to carry an extremely large "
                  "amount of stream on its circuits. "
-                 "To avoid potential route manipulation attacks, Tor has "
+                 "To avoid potential route manipulation attacks, Anon has "
                  "disabled use of this guard. "
                  "Use counts are %ld/%ld. Success counts are %ld/%ld. "
                  "%ld circuits completed, %ld were unusable, %ld collapsed, "
@@ -1418,7 +1418,7 @@ pathbias_measure_use_rate(entry_guard_t *guard)
         log_notice(LD_CIRC,
                  "Guard %s is failing to carry more streams on its "
                  "circuits than usual. "
-                 "Most likely this means the Tor network is overloaded "
+                 "Most likely this means the Anon network is overloaded "
                  "or your network connection is poor. "
                  "Use counts are %ld/%ld. Success counts are %ld/%ld. "
                  "%ld circuits completed, %ld were unusable, %ld collapsed, "
@@ -1475,7 +1475,7 @@ pathbias_measure_close_rate(entry_guard_t *guard)
           log_warn(LD_CIRC,
                  "Guard %s is failing an extremely large "
                  "amount of circuits. "
-                 "To avoid potential route manipulation attacks, Tor has "
+                 "To avoid potential route manipulation attacks, Anon has "
                  "disabled use of this guard. "
                  "Success counts are %ld/%ld. Use counts are %ld/%ld. "
                  "%ld circuits completed, %ld were unusable, %ld collapsed, "
@@ -1523,7 +1523,7 @@ pathbias_measure_close_rate(entry_guard_t *guard)
         log_warn(LD_CIRC,
                  "Guard %s is failing a very large "
                  "amount of circuits. "
-                 "Most likely this means the Tor network is "
+                 "Most likely this means the Anon network is "
                  "overloaded, but it could also mean an attack against "
                  "you or potentially the guard itself. "
                  "Success counts are %ld/%ld. Use counts are %ld/%ld. "
@@ -1548,7 +1548,7 @@ pathbias_measure_close_rate(entry_guard_t *guard)
         log_notice(LD_CIRC,
                  "Guard %s is failing more circuits than "
                  "usual. "
-                 "Most likely this means the Tor network is overloaded. "
+                 "Most likely this means the Anon network is overloaded. "
                  "Success counts are %ld/%ld. Use counts are %ld/%ld. "
                  "%ld circuits completed, %ld were unusable, %ld collapsed, "
                  "and %ld timed out. "

--- a/src/feature/control/control_bootstrap.c
+++ b/src/feature/control/control_bootstrap.c
@@ -88,7 +88,7 @@ static const struct {
   /* Creating AP circuits */
 
   { BOOTSTRAP_STATUS_CIRCUIT_CREATE, "circuit_create",
-    "Establishing a Tor circuit" },
+    "Establishing a Anon circuit" },
   { BOOTSTRAP_STATUS_DONE, "done", "Done" },
 };
 #define N_BOOT_TO_STR (sizeof(boot_to_str_tab)/sizeof(boot_to_str_tab[0]))

--- a/src/feature/control/control_cmd.c
+++ b/src/feature/control/control_cmd.c
@@ -501,7 +501,7 @@ handle_control_takeownership(control_connection_t *conn,
   conn->is_owning_control_connection = 1;
 
   log_info(LD_CONTROL, "Control connection %d has taken ownership of this "
-           "Tor instance.",
+           "Anon instance.",
            (int)(conn->base_.s));
 
   send_control_done(conn);
@@ -524,7 +524,7 @@ handle_control_dropownership(control_connection_t *conn,
   conn->is_owning_control_connection = 0;
 
   log_info(LD_CONTROL, "Control connection %d has dropped ownership of this "
-           "Tor instance.",
+           "Anon instance.",
            (int)(conn->base_.s));
 
   send_control_done(conn);
@@ -1390,7 +1390,7 @@ handle_control_dropguards(control_connection_t *conn,
   if (! have_warned) {
     log_warn(LD_CONTROL, "DROPGUARDS is dangerous; make sure you understand "
              "the risks before using it. It may be removed in a future "
-             "version of Tor.");
+             "version of Anon.");
     have_warned = 1;
   }
 
@@ -1415,7 +1415,7 @@ handle_control_droptimeouts(control_connection_t *conn,
   if (! have_warned) {
     log_warn(LD_CONTROL, "DROPTIMEOUTS is dangerous; make sure you understand "
              "the risks before using it. It may be removed in a future "
-             "version of Tor.");
+             "version of Anon.");
     have_warned = 1;
   }
 
@@ -1750,7 +1750,7 @@ handle_control_add_onion(control_connection_t *conn,
      * (I've deliberately written them out in full here to aid searchability.)
      */
     control_printf_endreply(conn, 512,
-                            "Tor is in %sanonymous hidden service " "mode",
+                            "Anon is in %sanonymous hidden service " "mode",
                             non_anonymous ? "" : "non-");
     goto out;
   }

--- a/src/feature/dirauth/process_descs.c
+++ b/src/feature/dirauth/process_descs.c
@@ -402,7 +402,7 @@ dirserv_rejects_tor_version(const char *platform,
     return false;
 
   static const char please_upgrade_string[] =
-    "Tor version is insecure or unsupported. Please upgrade!";
+    "Anon version is insecure or unsupported. Please upgrade!";
 
   if (!tor_version_as_new_as(platform,
         dirauth_get_options()->MinimalAcceptedServerVersion)) {
@@ -812,7 +812,7 @@ dirserv_add_descriptor(routerinfo_t *ri, const char **msg, const char *source)
       "recorded a different RSA identity for this Ed25519 identity (or vice "
       "versa.) Did you replace or copy some of your key files, but not "
       "the others? You should either restore the expected keypair, or "
-      "delete your keys and restart Tor to start your relay with a new "
+      "delete your keys and restart Anon to start your relay with a new "
       "identity.";
     r = ROUTER_AUTHDIR_REJECTS;
     goto fail;

--- a/src/feature/dirauth/shared_random_state.c
+++ b/src/feature/dirauth/shared_random_state.c
@@ -722,7 +722,7 @@ disk_state_save_to_disk(void)
   state = config_dump(get_srs_mgr(), NULL, sr_disk_state, 0, 0);
   format_local_iso_time(tbuf, now);
   tor_asprintf(&content,
-               "# Tor shared random state file last generated on %s "
+               "# Anon shared random state file last generated on %s "
                "local time\n"
                "# Other times below are in UTC\n"
                "# Please *do not* edit this file.\n\n%s",

--- a/src/feature/dirclient/dirclient.c
+++ b/src/feature/dirclient/dirclient.c
@@ -1182,7 +1182,7 @@ directory_request_set_dir_from_routerstatus(directory_request_t *req)
       routerset_contains_routerstatus(options->ExcludeNodes, status, -1)) {
     log_warn(LD_DIR, "Wanted to contact directory mirror %s for %s, but "
              "it's in our ExcludedNodes list and StrictNodes is set. "
-             "Skipping. This choice might make your Tor not work.",
+             "Skipping. This choice might make your Anon not work.",
              routerstatus_describe(status),
              dir_conn_purpose_to_string(req->dir_purpose));
     return -1;

--- a/src/feature/keymgt/loadkey.c
+++ b/src/feature/keymgt/loadkey.c
@@ -66,7 +66,7 @@ init_key_from_file(const char *fname, int generate, int severity,
           if (try_locking(get_options(), 0)<0) {
             /* Make sure that --list-fingerprint only creates new keys
              * if there is no possibility for a deadlock. */
-            tor_log(severity, LD_FS, "Another Tor process has locked \"%s\". "
+            tor_log(severity, LD_FS, "Another Anon process has locked \"%s\". "
                     "Not writing any new keys.", fname);
             /*XXXX The 'other process' might make a key in a second or two;
              * maybe we should wait for it. */

--- a/src/feature/keymgt/loadkey.c
+++ b/src/feature/keymgt/loadkey.c
@@ -534,7 +534,7 @@ ed_key_init_from_file(const char *fname, uint32_t flags,
       !(flags & INIT_ED_KEY_MISSING_SECRET_OK)) {
     if (have_encrypted_secret_file) {
       tor_log(severity, LD_OR, "We needed to load a secret key from %s, "
-              "but it was encrypted. Try 'tor --keygen' instead, so you "
+              "but it was encrypted. Try 'anon --keygen' instead, so you "
               "can enter the passphrase.",
               secret_fname);
     } else if (offline_secret) {
@@ -546,7 +546,7 @@ ed_key_init_from_file(const char *fname, uint32_t flags,
               "but couldn't find it. %s", secret_fname,
               (flags & INIT_ED_KEY_SUGGEST_KEYGEN) ?
               "If you're keeping your master secret key offline, you will "
-              "need to run 'tor --keygen' to generate new signing keys." :
+              "need to run 'anon --keygen' to generate new signing keys." :
               "Did you forget to copy it over when you copied the rest of the "
               "signing key material?");
     }

--- a/src/feature/nodelist/networkstatus.c
+++ b/src/feature/nodelist/networkstatus.c
@@ -1799,7 +1799,7 @@ reload_consensus_from_file(const char *fname,
     log_notice(LD_GENERAL, "Looks like the above failures are probably "
                "because of a CRLF in consensus file %s; falling back to "
                "read_file_to_string. Nothing to worry about: this file "
-               "was probably saved by an earlier version of Tor.",
+               "was probably saved by an earlier version of Anon.",
                escaped(fname));
     char *content = read_file_to_str(fname, RFTS_IGNORE_MISSING, NULL);
     rv = networkstatus_set_current_consensus(content, strlen(content),
@@ -1901,7 +1901,7 @@ warn_early_consensus(const networkstatus_t *c, const char *flavor,
   format_iso_time(tbuf, c->valid_after);
   format_time_interval(dbuf, sizeof(dbuf), delta);
   log_warn(LD_GENERAL, "Our clock is %s behind the time published in the "
-           "consensus network status document (%s UTC).  Tor needs an "
+           "consensus network status document (%s UTC).  Anon needs an "
            "accurate clock to work correctly. Please check your time and "
            "date settings!", dbuf, tbuf);
   tor_asprintf(&flavormsg, "%s flavor consensus", flavor);
@@ -2267,7 +2267,7 @@ routers_update_all_from_networkstatus(time_t now, int dir_version)
                "The directory authorities don't recommend any versions.");
     } else if (status == VS_NEW || status == VS_NEW_IN_SERIES) {
       if (!have_warned_about_new_version) {
-        log_notice(LD_GENERAL, "This version of Tor (%s) is newer than any "
+        log_notice(LD_GENERAL, "This version of Anon (%s) is newer than any "
                    "recommended version%s, according to the directory "
                    "authorities. Recommended versions are: %s",
                    VERSION,
@@ -2280,7 +2280,7 @@ routers_update_all_from_networkstatus(time_t now, int dir_version)
       }
     } else {
       log_warn(LD_GENERAL, "Please upgrade! "
-               "This version of Tor (%s) is %s, according to the directory "
+               "This version of Anon (%s) is %s, according to the directory "
                "authorities. Recommended versions are: %s",
                VERSION,
                status == VS_OLD ? "obsolete" : "not recommended",
@@ -2757,9 +2757,9 @@ networkstatus_check_required_protocols(const networkstatus_t *ns,
 
   if (!protover_all_supported(required, &missing)) {
     tor_asprintf(warning_out, "At least one protocol listed as required in "
-                 "the consensus is not supported by this version of Tor. "
-                 "You should upgrade. This version of Tor will not work as a "
-                 "%s on the Tor network. The missing protocols are: %s",
+                 "the consensus is not supported by this version of Anon. "
+                 "You should upgrade. This version of Anon will not work as a "
+                 "%s on the Anon network. The missing protocols are: %s",
                  func, missing);
     tor_free(missing);
     return 1;
@@ -2767,9 +2767,9 @@ networkstatus_check_required_protocols(const networkstatus_t *ns,
 
   if (! protover_all_supported(recommended, &missing)) {
     tor_asprintf(warning_out, "At least one protocol listed as recommended in "
-                 "the consensus is not supported by this version of Tor. "
-                 "You should upgrade. This version of Tor will eventually "
-                 "stop working as a %s on the Tor network. The missing "
+                 "the consensus is not supported by this version of Anon. "
+                 "You should upgrade. This version of Anon will eventually "
+                 "stop working as a %s on the Anon network. The missing "
                  "protocols are: %s",
                  func, missing);
     tor_free(missing);

--- a/src/feature/nodelist/nodelist.c
+++ b/src/feature/nodelist/nodelist.c
@@ -2647,7 +2647,7 @@ compute_frac_paths_available(const networkstatus_t *consensus,
     if (have_consensus_path == CONSENSUS_PATH_INTERNAL) {
       log_notice(LD_NET,
                  "The current consensus has no exit nodes. "
-                 "Tor can only build internal paths, "
+                 "Anon can only build internal paths, "
                  "such as paths to onion services.");
 
       /* However, exit nodes can reachability self-test using this consensus,
@@ -2657,7 +2657,7 @@ compute_frac_paths_available(const networkstatus_t *consensus,
     } else if (old_have_consensus_path == CONSENSUS_PATH_INTERNAL) {
       log_notice(LD_NET,
                  "The current consensus contains exit nodes. "
-                 "Tor can build exit and internal paths.");
+                 "Anon can build exit and internal paths.");
     }
   }
 

--- a/src/feature/relay/ext_orport.c
+++ b/src/feature/relay/ext_orport.c
@@ -307,7 +307,7 @@ connection_ext_or_auth_handle_client_nonce(connection_t *conn)
   if (!ext_or_auth_cookie_is_set) { /* this should not happen */
     log_warn(LD_BUG, "Extended ORPort authentication cookie was not set. "
              "That's weird since we should have done that on startup. "
-             "This might be a Tor bug, please file a bug report. ");
+             "This might be a Anon bug, please file a bug report. ");
     return -1;
   }
 

--- a/src/feature/relay/relay_config.c
+++ b/src/feature/relay/relay_config.c
@@ -412,7 +412,7 @@ check_and_prune_server_ports(smartlist_t *ports,
   if (n_orport_advertised && !n_orport_advertised_ipv4 &&
       !options->BridgeRelay) {
     log_warn(LD_CONFIG, "Configured public relay to listen only on an IPv6 "
-             "address. Tor needs to listen on an IPv4 address too.");
+             "address. Anon needs to listen on an IPv4 address too.");
     r = -1;
   }
   if (n_dirport_advertised && n_dirport_listeners_v4 == 0) {
@@ -430,7 +430,7 @@ check_and_prune_server_ports(smartlist_t *ports,
     log_warn(LD_CONFIG,
           "You have set AccountingMax to use hibernation. You have also "
           "chosen a low DirPort or OrPort%s."
-          "This combination can make Tor stop "
+          "This combination can make Anon stop "
           "working when it tries to re-attach the port after a period of "
           "hibernation. Please choose a different port or turn off "
           "hibernation unless you know this combination will work on your "
@@ -579,7 +579,7 @@ options_validate_relay_os(const or_options_t *old_options,
   if (!strcmpstart(uname, "Windows 95") ||
       !strcmpstart(uname, "Windows 98") ||
       !strcmpstart(uname, "Windows Me")) {
-    log_warn(LD_CONFIG, "Tor is running as a server, but you are "
+    log_warn(LD_CONFIG, "Anon is running as a server, but you are "
         "running %s; this probably won't work. See "
         "https://www.torproject.org/docs/faq.html#BestOSForRelay "
         "for details.", uname);
@@ -1124,9 +1124,9 @@ options_validate_relay_mode(const or_options_t *old_options,
   if (server_mode(options) && options->RendConfigLines &&
       !hs_service_non_anonymous_mode_enabled(options))
     log_warn(LD_CONFIG,
-        "Tor is currently configured as a relay and a hidden service. "
+        "Anon is currently configured as a relay and a hidden service. "
         "That's not very secure: you should probably run your hidden service "
-        "in a separate Tor process, at least -- see "
+        "in a separate Anon process, at least -- see "
         "https://bugs.torproject.org/tpo/core/tor/8742.");
 
   if (options->BridgeRelay && options->DirPort_set) {
@@ -1154,7 +1154,7 @@ options_validate_relay_mode(const or_options_t *old_options,
   if (options->BridgeRelay == 1 && !(options->ExitRelay == 0 ||
       policy_using_default_exit_options(options))) {
     log_warn(LD_CONFIG, "BridgeRelay is 1, but ExitRelay is 1 or an "
-           "ExitPolicy is configured. Tor will start, but it will not "
+           "ExitPolicy is configured. Anon will start, but it will not "
            "function as an exit relay.");
   }
 

--- a/src/feature/relay/router.c
+++ b/src/feature/relay/router.c
@@ -568,7 +568,7 @@ log_new_relay_greeting(void)
     return;
 
   tor_log(LOG_NOTICE, LD_GENERAL, "You are running a new relay. "
-         "Thanks for helping the Tor network! If you wish to know "
+         "Thanks for helping the Anon network! If you wish to know "
          "what will happen in the upcoming weeks regarding its usage, "
          "have a look at https://blog.torproject.org/lifecycle-of-a"
          "-new-relay");
@@ -602,7 +602,7 @@ init_curve25519_keypair_from_file(curve25519_keypair_t *keys_out,
           if (try_locking(get_options(), 0)<0) {
             /* Make sure that --list-fingerprint only creates new keys
              * if there is no possibility for a deadlock. */
-            tor_log(severity, LD_FS, "Another Tor process has locked \"%s\". "
+            tor_log(severity, LD_FS, "Another Anon process has locked \"%s\". "
                     "Not writing any new keys.", fname);
             /*XXXX The 'other process' might make a key in a second or two;
              * maybe we should wait for it. */
@@ -916,7 +916,7 @@ router_write_fingerprint(int hashed, int ed25519_identity)
     goto done;
   }
 
-  log_notice(LD_GENERAL, "Your Tor %s identity key %sfingerprint is '%s %s'",
+  log_notice(LD_GENERAL, "Your Anon %s identity key %sfingerprint is '%s %s'",
              hashed ? "bridge's hashed" : "server's",
              ed25519_identity ? "ed25519 " : "",
              options->Nickname, fingerprint);
@@ -953,7 +953,7 @@ init_keys_client(void)
   set_client_identity_key(prkey);
   /* Create a TLS context. */
   if (router_initialize_tls_context() < 0) {
-    log_err(LD_GENERAL,"Error creating TLS context for Tor client.");
+    log_err(LD_GENERAL,"Error creating TLS context for Anon client.");
     return -1;
   }
   return 0;
@@ -2744,7 +2744,7 @@ check_descriptor_ipaddress_changed(time_t now)
 STATIC void
 get_platform_str(char *platform, size_t len)
 {
-  tor_snprintf(platform, len, "Tor %s on %s",
+  tor_snprintf(platform, len, "Anon %s on %s",
                get_short_version(), get_uname());
 }
 

--- a/src/feature/relay/router.c
+++ b/src/feature/relay/router.c
@@ -2744,7 +2744,7 @@ check_descriptor_ipaddress_changed(time_t now)
 STATIC void
 get_platform_str(char *platform, size_t len)
 {
-  tor_snprintf(platform, len, "Anon %s on %s",
+  tor_snprintf(platform, len, "Tor %s on %s",
                get_short_version(), get_uname());
 }
 

--- a/src/feature/relay/routerkeys.c
+++ b/src/feature/relay/routerkeys.c
@@ -148,7 +148,7 @@ load_ed_keys(const or_options_t *options, time_t now)
                "If the master identity key was not moved or encrypted "
                "with a passphrase, this will be done automatically and "
                "no further action is required. Otherwise, provide the "
-               "necessary data using 'tor --keygen' to do it manually.",
+               "necessary data using 'anon --keygen' to do it manually.",
             (NULL == use_signing) ? "I don't have one" :
             EXPIRES_SOON(check_signing_cert, 0) ? "the one I have is expired" :
                "you asked me to make one with --keygen",
@@ -161,13 +161,13 @@ load_ed_keys(const or_options_t *options, time_t now)
                "If the master identity key was not moved or encrypted "
                "with a passphrase, this will be done automatically and "
                "no further action is required. Otherwise, provide the "
-               "necessary data using 'tor --keygen' to do it manually.");
+               "necessary data using 'anon --keygen' to do it manually.");
   } else if (want_new_signing_key) {
     log_notice(LD_OR, "It looks like I should try to generate and sign a "
                "new medium-term signing key, because the one I have is "
                "going to expire soon. But OfflineMasterKey is set, so I "
                "won't try to load a permanent master identity key. You "
-               "will need to use 'tor --keygen' to make a new signing "
+               "will need to use 'anon --keygen' to make a new signing "
                "key and certificate.");
   }
 

--- a/src/feature/relay/routerkeys.h
+++ b/src/feature/relay/routerkeys.h
@@ -115,11 +115,11 @@ make_tap_onion_key_crosscert(const crypto_pk_t *onion_key,
 /* This calls is used outside of relay mode, but only to implement
  * CMD_KEY_EXPIRATION */
 #define log_cert_expiration()                                           \
-  (puts("Not available: Tor has been compiled without relay support"), 0)
+  (puts("Not available: Anon has been compiled without relay support"), 0)
 /* This calls is used outside of relay mode, but only to implement
  * CMD_KEYGEN. */
 #define load_ed_keys(x,y)                                                \
-  (puts("Not available: Tor has been compiled without relay support"), 0)
+  (puts("Not available: Anon has been compiled without relay support"), 0)
 
 #endif /* defined(HAVE_MODULE_RELAY) */
 

--- a/src/feature/relay/transport_config.c
+++ b/src/feature/relay/transport_config.c
@@ -206,7 +206,7 @@ options_validate_server_transport(const or_options_t *old_options,
   config_line_t *cl;
 
   if (options->ServerTransportPlugin && !server_mode(options)) {
-    log_notice(LD_GENERAL, "Tor is not configured as a relay but you specified"
+    log_notice(LD_GENERAL, "Anon is not configured as a relay but you specified"
                " a ServerTransportPlugin line (%s). The ServerTransportPlugin "
                "line will be ignored.",
                escaped(options->ServerTransportPlugin->value));
@@ -273,7 +273,7 @@ options_act_server_transport(const or_options_t *old_options)
   if (options->ServerTransportPlugin &&
       !options->ExtORPort_lines) {
     log_notice(LD_CONFIG, "We use pluggable transports but the Extended "
-               "ORPort is disabled. Tor and your pluggable transports proxy "
+               "ORPort is disabled. Anon and your pluggable transports proxy "
                "communicate with each other via the Extended ORPort so it "
                "is suggested you enable it: it will also allow your Bridge "
                "to collect statistics about its clients that use pluggable "

--- a/src/lib/cc/torint.h
+++ b/src/lib/cc/torint.h
@@ -126,11 +126,11 @@ typedef int32_t ssize_t;
 #define SIZE_T_CEILING  ((size_t)(SSIZE_MAX-16))
 
 #if SIZEOF_INT > SIZEOF_VOID_P
-#error "sizeof(int) > sizeof(void *) - Can't build Tor here."
+#error "sizeof(int) > sizeof(void *) - Can't build Anon here."
 #endif
 
 #if SIZEOF_UNSIGNED_INT > SIZEOF_VOID_P
-#error "sizeof(unsigned int) > sizeof(void *) - Can't build Tor here."
+#error "sizeof(unsigned int) > sizeof(void *) - Can't build Anon here."
 #endif
 
 #endif /* !defined(TOR_TORINT_H) */

--- a/src/lib/compress/compress_zstd.c
+++ b/src/lib/compress/compress_zstd.c
@@ -523,7 +523,7 @@ tor_zstd_warn_if_version_mismatched(void)
                             ZSTD_versionNumber());
 
     log_info(LD_GENERAL,
-             "Tor was compiled with zstd %s, but is running with zstd %s. "
+             "Anon was compiled with zstd %s, but is running with zstd %s. "
              "For ABI compatibility reasons, we'll avoid using advanced zstd "
              "functionality.",
              header_version, runtime_version);

--- a/src/lib/confmgt/confmgt.c
+++ b/src/lib/confmgt/confmgt.c
@@ -661,7 +661,7 @@ config_assign_value(const config_mgr_t *mgr, void *options,
     log_warn(LD_GENERAL, "Skipping obsolete configuration option \"%s\".",
              var->cvar->member.name);
   } else if (config_var_has_flag(var->cvar, CFLG_WARN_DISABLED)) {
-    log_warn(LD_GENERAL, "This copy of Tor was built without support for "
+    log_warn(LD_GENERAL, "This copy of Anon was built without support for "
              "the option \"%s\". Skipping.", var->cvar->member.name);
   }
 
@@ -693,7 +693,7 @@ warn_deprecated_option(const char *what, const char *why)
 {
   const char *space = (why && strlen(why)) ? " " : "";
   log_warn(LD_CONFIG, "The %s option is deprecated, and will most likely "
-           "be removed in a future version of Tor.%s%s (If you think this is "
+           "be removed in a future version of Anon.%s%s (If you think this is "
            "a mistake, please let us know!)",
            what, space, why);
 }
@@ -1192,7 +1192,7 @@ config_check_immutable_flags(const config_format_t *fmt,
 
     if (! struct_var_eq(old_options, new_options, &v->member)) {
       tor_asprintf(msg_out,
-                   "While Tor is running, changing %s is not allowed",
+                   "While Anon is running, changing %s is not allowed",
                    v->member.name);
       return -1;
     }

--- a/src/lib/crypt_ops/crypto_openssl_mgt.c
+++ b/src/lib/crypt_ops/crypto_openssl_mgt.c
@@ -137,7 +137,7 @@ crypto_openssl_get_header_version_str(void)
 
 #ifndef COCCI
 #ifndef OPENSSL_THREADS
-#error "OpenSSL has been built without thread support. Tor requires an \
+#error "OpenSSL has been built without thread support. Anon requires an \
  OpenSSL library with thread support enabled."
 #endif
 #endif /* !defined(COCCI) */

--- a/src/lib/crypt_ops/crypto_rand.c
+++ b/src/lib/crypt_ops/crypto_rand.c
@@ -198,7 +198,7 @@ crypto_strongest_rand_syscall(uint8_t *out, size_t out_len)
       /* Useful log message for errno. */
       if (errno == ENOSYS) {
         log_notice(LD_CRYPTO, "Can't get entropy from getrandom()."
-                   " You are running a version of Tor built to support"
+                   " You are running a version of Anon built to support"
                    " getrandom(), but the kernel doesn't implement this"
                    " function--probably because it is too old?"
                    " Trying fallback method instead.");

--- a/src/lib/crypt_ops/crypto_rand_fast.c
+++ b/src/lib/crypt_ops/crypto_rand_fast.c
@@ -183,7 +183,7 @@ crypto_fast_rng_new_from_seed(const uint8_t *seed)
   tor_assertf(inherit != INHERIT_RES_KEEP,
               "We failed to create a non-inheritable memory region, even "
               "though we believed such a failure to be impossible! This is "
-              "probably a bug in Tor support for your platform; please report "
+              "probably a bug in Anon support for your platform; please report "
               "it.");
 #endif /* defined(CHECK_PID) || ... */
   return result;

--- a/src/lib/fs/dir.c
+++ b/src/lib/fs/dir.c
@@ -200,7 +200,7 @@ check_private_dir,(const char *dirname, cpd_check_t check,
     }
 
     log_warn(LD_FS, "%s is not owned by this user (%s, %d) but by "
-        "%s (%d). Perhaps you are running Tor as the wrong user?",
+        "%s (%d). Perhaps you are running Anon as the wrong user?",
              dirname, process_ownername, (int)running_uid,
              file_ownername, (int)st.st_uid);
 
@@ -218,7 +218,7 @@ check_private_dir,(const char *dirname, cpd_check_t check,
     gr = getgrgid(st.st_gid);
 
     log_warn(LD_FS, "%s is not owned by this group (%s, %d) but by group "
-             "%s (%d).  Are you running Tor as the wrong user?",
+             "%s (%d).  Are you running Anon as the wrong user?",
              dirname, process_groupname, (int)running_gid,
              gr ?  gr->gr_name : "<unknown>", (int)st.st_gid);
 

--- a/src/lib/log/log.c
+++ b/src/lib/log/log.c
@@ -315,7 +315,7 @@ log_tor_version(logfile_t *lf, int reset)
                  "%s opening %slog file.\n", appname, is_new?"new ":"");
   } else {
     tor_snprintf(buf+n, sizeof(buf)-n,
-                 "Tor %s opening %slog file.\n", VERSION, is_new?"new ":"");
+                 "Anon %s opening %slog file.\n", VERSION, is_new?"new ":"");
   }
   if (write_all_to_fd_minimal(lf->fd, buf, strlen(buf)) < 0) /* error */
     return -1; /* failed */

--- a/src/lib/malloc/map_anon.c
+++ b/src/lib/malloc/map_anon.c
@@ -79,7 +79,7 @@
 
 #if defined(HAVE_MINHERIT) && !defined(FLAG_ZERO) && !defined(FLAG_NOINHERIT)
 #warning "minherit() is defined, but FLAG_ZERO/NOINHERIT are not."
-#warning "This is probably a bug in Tor's support for this platform."
+#warning "This is probably a bug in Anon's support for this platform."
 #endif
 
 /**

--- a/src/lib/net/socket.c
+++ b/src/lib/net/socket.c
@@ -51,7 +51,7 @@ network_init(void)
     return -1;
   }
   if (sizeof(SOCKET) != sizeof(tor_socket_t)) {
-    log_warn(LD_BUG,"The tor_socket_t type does not match SOCKET in size; Tor "
+    log_warn(LD_BUG,"The tor_socket_t type does not match SOCKET in size; Anon "
              "might not work. (Sizes are %d and %d respectively.)",
              (int)sizeof(tor_socket_t), (int)sizeof(SOCKET));
   }

--- a/src/lib/process/restrict.c
+++ b/src/lib/process/restrict.c
@@ -44,7 +44,7 @@ tor_disable_debugger_attach(void)
 {
   int r = -1;
   log_debug(LD_CONFIG,
-            "Attempting to disable debugger attachment to Tor for "
+            "Attempting to disable debugger attachment to Anon for "
             "unprivileged users.");
 #if defined(__linux__) && defined(HAVE_SYS_PRCTL_H) \
   && defined(HAVE_PRCTL) && defined(PR_SET_DUMPABLE)

--- a/src/lib/process/setuid.c
+++ b/src/lib/process/setuid.c
@@ -284,7 +284,7 @@ switch_id(const char *user, const unsigned flags)
                "anonrc, check whether it was specified on the command line "
                "by a startup script.)", user);
     } else {
-      log_warn(LD_GENERAL, "If you set the \"User\" option, you must start Tor"
+      log_warn(LD_GENERAL, "If you set the \"User\" option, you must start Anon"
                " as root.");
     }
     return -1;

--- a/src/lib/process/setuid.c
+++ b/src/lib/process/setuid.c
@@ -278,7 +278,7 @@ switch_id(const char *user, const unsigned flags)
     log_warn(LD_GENERAL, "Error setting groups to gid %d: \"%s\".",
              (int)pw->pw_gid, strerror(errno));
     if (old_uid == pw->pw_uid) {
-      log_warn(LD_GENERAL, "Tor is already running as %s.  You do not need "
+      log_warn(LD_GENERAL, "Anon is already running as %s.  You do not need "
                "the \"User\" option if you are already running as the user "
                "you want to be.  (If you did not set the User option in your "
                "anonrc, check whether it was specified on the command line "

--- a/src/lib/sandbox/sandbox.c
+++ b/src/lib/sandbox/sandbox.c
@@ -2280,7 +2280,7 @@ sandbox_init(sandbox_cfg_t *cfg)
 #elif defined(__linux__)
   (void)cfg;
   log_warn(LD_GENERAL,
-           "This version of Tor was built without support for sandboxing. To "
+           "This version of Anon was built without support for sandboxing. To "
            "build with support for sandboxing on Linux, you must have "
            "libseccomp and its necessary header files (e.g. seccomp.h).");
   return 0;

--- a/src/lib/thread/numcpus.c
+++ b/src/lib/thread/numcpus.c
@@ -54,7 +54,7 @@ compute_num_cpus_impl(void)
   } else if (cpus_onln > 0 && cpus_conf > 0) {
     if (cpus_onln < cpus_conf) {
       log_info(LD_GENERAL, "I think we have %ld CPUS, but only %ld of them "
-               "are available. Telling Tor to only use %ld. You can over"
+               "are available. Telling Anon to only use %ld. You can over"
                "ride this with the NumCPUs option",
                cpus_conf, cpus_onln, cpus_onln);
     }

--- a/src/test/rng_test_helpers.c
+++ b/src/test/rng_test_helpers.c
@@ -22,7 +22,7 @@
 #include "test/rng_test_helpers.h"
 
 #ifndef TOR_UNIT_TESTS
-#error "No. Never link this code into Tor proper."
+#error "No. Never link this code into Anon proper."
 #endif
 
 /**

--- a/src/test/test_config.c
+++ b/src/test/test_config.c
@@ -1522,7 +1522,7 @@ test_config_find_my_address(void *arg)
   retval = find_my_address(options, p->family, LOG_NOTICE, &resolved_addr,
                            &method_used, &hostname_out);
 
-  expect_log_msg_containing("is a private IP address. Tor relays that "
+  expect_log_msg_containing("is a private IP address. Anon relays that "
                             "use the default DirAuthorities must have "
                             "public IP addresses.");
   teardown_capture_of_logs();

--- a/src/test/test_dir.c
+++ b/src/test/test_dir.c
@@ -261,7 +261,7 @@ get_new_platform_line(void)
   char *line = NULL;
 
   tor_asprintf(&line,
-               "platform Tor %s on %s\n",
+               "platform Anon %s on %s\n",
                VERSION, get_uname());
   tor_assert(line);
 

--- a/src/test/test_dir.c
+++ b/src/test/test_dir.c
@@ -261,7 +261,7 @@ get_new_platform_line(void)
   char *line = NULL;
 
   tor_asprintf(&line,
-               "platform Anon %s on %s\n",
+               "platform Tor %s on %s\n",
                VERSION, get_uname());
   tor_assert(line);
 

--- a/src/test/test_include.py
+++ b/src/test/test_include.py
@@ -31,15 +31,15 @@ def wait_for_log(s):
         l = tor_process.stdout.readline()
         l = l.decode('utf8', 'backslashreplace')
         if s in l:
-            logging.info('Tor logged: "{}"'.format(l.strip()))
+            logging.info('Anon logged: "{}"'.format(l.strip()))
             return
         # readline() returns a blank string when there is no output
         # avoid busy-waiting
         if len(l) == 0:
-            logging.debug('Tor has not logged anything, waiting for "{}"'.format(s))
+            logging.debug('Anon has not logged anything, waiting for "{}"'.format(s))
             time.sleep(LOG_WAIT)
         else:
-            logging.info('Tor logged: "{}", waiting for "{}"'.format(l.strip(), s))
+            logging.info('Anon logged: "{}", waiting for "{}"'.format(l.strip(), s))
     fail('Could not find "{}" in logs after {} seconds'.format(s, LOG_TIMEOUT))
 
 def pick_random_port():
@@ -191,6 +191,6 @@ try:
 except OSError as e:
     if e.errno == errno.ESRCH: # errno 3: No such process
         # assume tor has already exited due to SIGNAL HALT
-        logging.warn("Tor has already exited")
+        logging.warn("Anon has already exited")
     else:
         raise

--- a/src/test/test_key_expiration.sh
+++ b/src/test/test_key_expiration.sh
@@ -130,25 +130,25 @@ if [ "$CASE1" = 1 ]; then
 
   ${TOR} ${QUIETLY} --key-expiration 2>"$FN" || true
   grep "No valid argument to --key-expiration found!" "$FN" >/dev/null || \
-    die "Tor didn't mention supported --key-expiration arguments"
+    die "Anon didn't mention supported --key-expiration arguments"
 
   echo "==== Case 1: ok"
 fi
 
 if [ "$CASE2" = 1 ]; then
-  echo "==== Case 2: Start Tor with --key-expiration 'sign' and make sure it"
+  echo "==== Case 2: Start Anon with --key-expiration 'sign' and make sure it"
   echo "             prints an expiration using ISO8601 date format."
 
   ${TOR} ${QUIETLY} --key-expiration sign 2>"$FN"
   grep "signing-cert-expiry: [0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\} [0-9]\{2\}:[0-9]\{2\}:[0-9]\{2\}" "$FN" >/dev/null || \
-    die "Tor didn't print an expiration"
+    die "Anon didn't print an expiration"
 
   echo "==== Case 2: ok"
 fi
 
 if [ "$CASE3" = 1 ]; then
-  echo "==== Case 3: Start Tor with --key-expiration 'sign', when there is no"
-  echo "             signing key, and make sure that Tor generates a new key"
+  echo "==== Case 3: Start Anon with --key-expiration 'sign', when there is no"
+  echo "             signing key, and make sure that Anon generates a new key"
   echo "             and prints its certificate's expiration."
 
   mv "${DATA_DIR}/keys/ed25519_signing_cert" \
@@ -156,10 +156,10 @@ if [ "$CASE3" = 1 ]; then
 
   ${TOR} --key-expiration sign > "$FN" 2>&1
   grep "It looks like I need to generate and sign a new medium-term signing key" "$FN" >/dev/null || \
-    die "Tor didn't create a new signing key"
+    die "Anon didn't create a new signing key"
   check_file "${DATA_DIR}/keys/ed25519_signing_cert"
   grep "signing-cert-expiry:" "$FN" >/dev/null || \
-    die "Tor didn't print an expiration"
+    die "Anon didn't print an expiration"
 
   mv "${DATA_DIR}/keys/ed25519_signing_cert.bak" \
      "${DATA_DIR}/keys/ed25519_signing_cert"
@@ -168,59 +168,59 @@ if [ "$CASE3" = 1 ]; then
 fi
 
 if [ "$CASE4" = 1 ]; then
-  echo "==== Case 4: Start Tor with --format iso8601 and make sure it prints an"
+  echo "==== Case 4: Start Anon with --format iso8601 and make sure it prints an"
   echo "             error message due to missing --key-expiration argument."
 
   ${TOR} --format iso8601 > "$FN" 2>&1 || true
   grep -- "--format specified without --key-expiration!" "$FN" >/dev/null || \
-    die "Tor didn't print a missing --key-expiration error message"
+    die "Anon didn't print a missing --key-expiration error message"
 
   echo "==== Case 4: ok"
 fi
 
 if [ "$CASE5" = 1 ]; then
-  echo "==== Case 5: Start Tor with --key-expiration 'sign' --format '' and"
+  echo "==== Case 5: Start Anon with --key-expiration 'sign' --format '' and"
   echo "             make sure it prints an error message due to missing value."
 
   ${TOR} --key-expiration sign --format > "$FN" 2>&1 || true
   grep "Command-line option '--format' with no value. Failing." "$FN" >/dev/null || \
-    die "Tor didn't print a missing format value error message"
+    die "Anon didn't print a missing format value error message"
 
   echo "==== Case 5: ok"
 fi
 
 if [ "$CASE6" = 1 ]; then
-  echo "==== Case 6: Start Tor with --key-expiration 'sign' --format 'invalid'"
+  echo "==== Case 6: Start Anon with --key-expiration 'sign' --format 'invalid'"
   echo "             and make sure it prints an error message due to invalid"
   echo "             value."
 
   ${TOR} --key-expiration sign --format invalid > "$FN" 2>&1 || true
   grep "Invalid --format value" "$FN" >/dev/null || \
-    die "Tor didn't print an invalid format value error message"
+    die "Anon didn't print an invalid format value error message"
 
   echo "==== Case 6: ok"
 fi
 
 if [ "$CASE7" = 1 ]; then
-  echo "==== Case 7: Start Tor with --key-expiration 'sign' --format 'iso8601'"
+  echo "==== Case 7: Start Anon with --key-expiration 'sign' --format 'iso8601'"
   echo "             and make sure it prints an expiration using ISO8601 date"
   echo "             format."
 
   ${TOR} ${QUIETLY} --key-expiration sign --format iso8601 2>"$FN"
   grep "signing-cert-expiry: [0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\} [0-9]\{2\}:[0-9]\{2\}:[0-9]\{2\}" "$FN" >/dev/null || \
-    die "Tor didn't print an expiration"
+    die "Anon didn't print an expiration"
 
   echo "==== Case 7: ok"
 fi
 
 if [ "$CASE8" = 1 ]; then
-  echo "==== Case 8: Start Tor with --key-expiration 'sign' --format 'timestamp'"
+  echo "==== Case 8: Start Anon with --key-expiration 'sign' --format 'timestamp'"
   echo "             and make sure it prints an expiration using timestamp date"
   echo "             format."
 
   ${TOR} ${QUIETLY} --key-expiration sign --format timestamp 2>"$FN"
   grep "signing-cert-expiry: [0-9]\{5,\}" "$FN" >/dev/null || \
-    die "Tor didn't print an expiration"
+    die "Anon didn't print an expiration"
 
   echo "==== Case 8: ok"
 fi

--- a/src/test/test_keygen.sh
+++ b/src/test/test_keygen.sh
@@ -131,7 +131,7 @@ check_file "${DATA_DIR}/orig/keys/ed25519_signing_secret_key"
 # Step 2: Start Tor with --keygen.  Make sure everything is there.
 mkdir "${DATA_DIR}/keygen"
 ${TOR} --DataDirectory "${DATA_DIR}/keygen" --keygen --no-passphrase 2>"${DATA_DIR}/keygen/stderr"
-grep "Not encrypting the secret key" "${DATA_DIR}/keygen/stderr" >/dev/null || die "Tor didn't declare that there would be no encryption"
+grep "Not encrypting the secret key" "${DATA_DIR}/keygen/stderr" >/dev/null || die "Anon didn't declare that there would be no encryption"
 
 check_dir "${DATA_DIR}/keygen/keys"
 check_file "${DATA_DIR}/keygen/keys/ed25519_master_id_public_key"
@@ -171,7 +171,7 @@ if ${TOR} --DataDirectory "${ME}" --list-fingerprint > "${ME}/stdout"; then
 fi
 check_files_eq "${SRC}/keys/ed25519_master_id_public_key" "${ME}/keys/ed25519_master_id_public_key"
 
-grep "We needed to load a secret key.*but couldn't find it" "${ME}/stdout" >/dev/null || die "Tor didn't declare that it was missing a secret key"
+grep "We needed to load a secret key.*but couldn't find it" "${ME}/stdout" >/dev/null || die "Anon didn't declare that it was missing a secret key"
 
 echo "==== Case 2A ok"
 fi
@@ -191,7 +191,7 @@ ${TOR} --DataDirectory "${ME}" --list-fingerprint > "${ME}/stdout" && dir "Someh
 check_files_eq "${SRC}/keys/ed25519_master_id_public_key" "${ME}/keys/ed25519_master_id_public_key"
 check_files_eq "${SRC}/keys/ed25519_master_id_secret_key_encrypted" "${ME}/keys/ed25519_master_id_secret_key_encrypted"
 
-grep "We needed to load a secret key.*but it was encrypted.*--keygen" "${ME}/stdout" >/dev/null || die "Tor didn't declare that it was missing a secret key and suggest --keygen."
+grep "We needed to load a secret key.*but it was encrypted.*--keygen" "${ME}/stdout" >/dev/null || die "Anon didn't declare that it was missing a secret key and suggest --keygen."
 
 echo "==== Case 2B ok"
 
@@ -206,7 +206,7 @@ SRC="${DATA_DIR}/orig"
 
 mkdir -p "${ME}/keys"
 cp "${SRC}/keys/ed25519_master_id_"* "${ME}/keys/"
-${TOR} --DataDirectory "${ME}" ${SILENTLY} --list-fingerprint >/dev/null || die "Tor failed when starting with only master key"
+${TOR} --DataDirectory "${ME}" ${SILENTLY} --list-fingerprint >/dev/null || die "Anon failed when starting with only master key"
 check_files_eq "${SRC}/keys/ed25519_master_id_public_key" "${ME}/keys/ed25519_master_id_public_key"
 check_files_eq "${SRC}/keys/ed25519_master_id_secret_key" "${ME}/keys/ed25519_master_id_secret_key"
 check_file "${ME}/keys/ed25519_signing_cert"
@@ -264,11 +264,11 @@ SRC="${DATA_DIR}/orig"
 
 mkdir -p "${ME}/keys"
 cp "${SRC}/keys/ed25519_master_id_secret_key" "${ME}/keys/"
-${TOR} --DataDirectory "${ME}" ${SILENTLY} --list-fingerprint > "${ME}/fp1" || die "Tor wouldn't start with only unencrypted secret key"
+${TOR} --DataDirectory "${ME}" ${SILENTLY} --list-fingerprint > "${ME}/fp1" || die "Anon wouldn't start with only unencrypted secret key"
 check_file "${ME}/keys/ed25519_master_id_public_key"
 check_file "${ME}/keys/ed25519_signing_cert"
 check_file "${ME}/keys/ed25519_signing_secret_key"
-${TOR} --DataDirectory "${ME}" ${SILENTLY} --list-fingerprint > "${ME}/fp2" || die "Tor wouldn't start again after starting once with only unencrypted secret key."
+${TOR} --DataDirectory "${ME}" ${SILENTLY} --list-fingerprint > "${ME}/fp2" || die "Anon wouldn't start again after starting once with only unencrypted secret key."
 
 check_files_eq "${ME}/fp1" "${ME}/fp2"
 
@@ -285,11 +285,11 @@ SRC="${DATA_DIR}/encrypted"
 
 mkdir -p "${ME}/keys"
 cp "${SRC}/keys/ed25519_master_id_secret_key_encrypted" "${ME}/keys/"
-${TOR} --DataDirectory "${ME}" --list-fingerprint >"${ME}/stdout" && die "Tor started with only encrypted secret key!"
+${TOR} --DataDirectory "${ME}" --list-fingerprint >"${ME}/stdout" && die "Anon started with only encrypted secret key!"
 check_no_file "${ME}/keys/ed25519_master_id_public_key"
 check_no_file "${ME}/keys/ed25519_master_id_public_key"
 
-grep "but not public key file" "${ME}/stdout" >/dev/null || die "Tor didn't declare it couldn't find a public key."
+grep "but not public key file" "${ME}/stdout" >/dev/null || die "Anon didn't declare it couldn't find a public key."
 
 echo "==== Case 5 ok"
 
@@ -306,12 +306,12 @@ mkdir -p "${ME}/keys"
 cp "${SRC}/keys/ed25519_master_id_secret_key_encrypted" "${ME}/keys/"
 cp "${SRC}/keys/ed25519_master_id_public_key" "${ME}/keys/"
 if ${TOR} --DataDirectory "${ME}" --list-fingerprint > "${ME}/stdout"; then
-  die "Tor started with encrypted secret key and no certs"
+  die "Anon started with encrypted secret key and no certs"
 fi
 check_no_file "${ME}/keys/ed25519_signing_cert"
 check_no_file "${ME}/keys/ed25519_signing_secret_key"
 
-grep "but it was encrypted" "${ME}/stdout" >/dev/null || die "Tor didn't declare that the secret key was encrypted."
+grep "but it was encrypted" "${ME}/stdout" >/dev/null || die "Anon didn't declare that the secret key was encrypted."
 
 echo "==== Case 6 ok"
 
@@ -400,7 +400,7 @@ if ${TOR} --DataDirectory "${ME}" --list-fingerprint >"${ME}/stdout"; then
   die "Successfully started with mismatched keys!?"
 fi
 
-grep "public_key does not match.*secret_key" "${ME}/stdout" >/dev/null || die "Tor didn't declare that there was a key mismatch"
+grep "public_key does not match.*secret_key" "${ME}/stdout" >/dev/null || die "Anon didn't declare that there was a key mismatch"
 
 echo "==== Case 10 ok"
 
@@ -418,7 +418,7 @@ if ${TOR} --DataDirectory "${ME}" --passphrase-fd 1 > "${ME}/stdout"; then
   die "Successfully started with passphrase-fd but no keygen?"
 fi
 
-grep "passphrase-fd specified without --keygen" "${ME}/stdout" >/dev/null || die "Tor didn't declare that there was a problem with the arguments."
+grep "passphrase-fd specified without --keygen" "${ME}/stdout" >/dev/null || die "Anon didn't declare that there was a problem with the arguments."
 
 echo "==== Case 11A ok"
 
@@ -436,7 +436,7 @@ if ${TOR} --DataDirectory "${ME}" --no-passphrase > "${ME}/stdout"; then
   die "Successfully started with no-passphrase but no keygen?"
 fi
 
-grep "no-passphrase specified without --keygen" "${ME}/stdout" >/dev/null || die "Tor didn't declare that there was a problem with the arguments."
+grep "no-passphrase specified without --keygen" "${ME}/stdout" >/dev/null || die "Anon didn't declare that there was a problem with the arguments."
 
 echo "==== Case 11B ok"
 
@@ -454,7 +454,7 @@ if ${TOR} --DataDirectory "${ME}" --newpass > "${ME}/stdout"; then
   die "Successfully started with newpass but no keygen?"
 fi
 
-grep "newpass specified without --keygen" "${ME}/stdout" >/dev/null || die "Tor didn't declare that there was a problem with the arguments."
+grep "newpass specified without --keygen" "${ME}/stdout" >/dev/null || die "Anon didn't declare that there was a problem with the arguments."
 
 echo "==== Case 11C ok"
 
@@ -494,7 +494,7 @@ if ${TOR} --DataDirectory "${ME}" --keygen --passphrase-fd ewigeblumenkraft > "$
   die "Successfully started with bogus passphrase-fd?"
 fi
 
-grep "Invalid --passphrase-fd value" "${ME}/stdout" >/dev/null || die "Tor didn't declare that there was a problem with the arguments."
+grep "Invalid --passphrase-fd value" "${ME}/stdout" >/dev/null || die "Anon didn't declare that there was a problem with the arguments."
 
 echo "==== Case 11E ok"
 
@@ -513,7 +513,7 @@ if ${TOR} --DataDirectory "${ME}" --keygen --passphrase-fd 1 --no-passphrase > "
   die "Successfully started with bogus passphrase-fd combination?"
 fi
 
-grep "no-passphrase specified with --passphrase-fd" "${ME}/stdout" >/dev/null || die "Tor didn't declare that there was a problem with the arguments."
+grep "no-passphrase specified with --passphrase-fd" "${ME}/stdout" >/dev/null || die "Anon didn't declare that there was a problem with the arguments."
 
 echo "==== Case 11F ok"
 

--- a/src/test/test_mainloop.c
+++ b/src/test/test_mainloop.c
@@ -140,7 +140,7 @@ test_mainloop_update_time_jumps(void *arg)
   mt_now += 4000*BILLION;
   monotime_coarse_set_mock_time_nsec(mt_now);
   update_current_time(now);
-  expect_single_log_msg_containing("Tor has been idle for 4000 seconds");
+  expect_single_log_msg_containing("Anon has been idle for 4000 seconds");
   tt_int_op(approx_time(), OP_EQ, now);
   tt_int_op(get_uptime(), OP_EQ, 5);
 

--- a/src/test/test_options.c
+++ b/src/test/test_options.c
@@ -495,7 +495,7 @@ test_options_validate__uname_for_server(void *ignored)
   MOCK(get_uname, fixed_get_uname);
   fixed_get_uname_result = "Windows 95";
   options_validate(NULL, tdata->opt, &msg);
-  expect_log_msg("Tor is running as a server, but you"
+  expect_log_msg("Anon is running as a server, but you"
            " are running Windows 95; this probably won't work. See https://www"
            ".torproject.org/docs/faq.html#BestOSForRelay for details.\n");
   tor_free(msg);
@@ -503,7 +503,7 @@ test_options_validate__uname_for_server(void *ignored)
   fixed_get_uname_result = "Windows 98";
   mock_clean_saved_logs();
   options_validate(NULL, tdata->opt, &msg);
-  expect_log_msg("Tor is running as a server, but you"
+  expect_log_msg("Anon is running as a server, but you"
            " are running Windows 98; this probably won't work. See https://www"
            ".torproject.org/docs/faq.html#BestOSForRelay for details.\n");
   tor_free(msg);
@@ -511,7 +511,7 @@ test_options_validate__uname_for_server(void *ignored)
   fixed_get_uname_result = "Windows Me";
   mock_clean_saved_logs();
   options_validate(NULL, tdata->opt, &msg);
-  expect_log_msg("Tor is running as a server, but you"
+  expect_log_msg("Anon is running as a server, but you"
            " are running Windows Me; this probably won't work. See https://www"
            ".torproject.org/docs/faq.html#BestOSForRelay for details.\n");
   tor_free(msg);
@@ -519,7 +519,7 @@ test_options_validate__uname_for_server(void *ignored)
   fixed_get_uname_result = "Windows 2000";
   mock_clean_saved_logs();
   options_validate(NULL, tdata->opt, &msg);
-  expect_no_log_msg("Tor is running as a server, but you ");
+  expect_no_log_msg("Anon is running as a server, but you ");
   tor_free(msg);
 
  done:
@@ -1008,9 +1008,9 @@ test_options_validate__relay_with_hidden_services(void *ignored)
   ret = options_validate(NULL, tdata->opt, &msg);
   tt_int_op(ret, OP_EQ, 0);
   expect_log_msg(
-            "Tor is currently configured as a relay and a hidden service. "
+            "Anon is currently configured as a relay and a hidden service. "
             "That's not very secure: you should probably run your hidden servi"
-            "ce in a separate Tor process, at least -- see "
+            "ce in a separate Anon process, at least -- see "
             "https://bugs.torproject.org/tpo/core/tor/8742.\n");
 
  done:
@@ -1032,7 +1032,7 @@ test_options_validate__listen_ports(void *ignored)
   expect_log_msg("SocksPort, TransPort, NATDPort, DNSPort, and ORPort "
                  "are all undefined, and there aren't any hidden services "
                  "configured. "
-                 " Tor will still run, but probably won't do anything.\n");
+                 " Anon will still run, but probably won't do anything.\n");
  done:
   teardown_capture_of_logs();
   free_options_test_data(tdata);
@@ -1223,7 +1223,7 @@ test_options_validate__exclude_nodes(void *ignored)
   tt_int_op(ret, OP_EQ, 0);
   expect_log_msg(
             "You have asked to exclude certain relays from all positions "
-            "in your circuits. Expect hidden services and other Tor "
+            "in your circuits. Expect hidden services and other Anon "
             "features to be broken in unpredictable ways.\n");
   tor_free(msg);
 
@@ -1234,7 +1234,7 @@ test_options_validate__exclude_nodes(void *ignored)
   tt_int_op(ret, OP_EQ, 0);
   expect_no_log_msg(
             "You have asked to exclude certain relays from all positions "
-            "in your circuits. Expect hidden services and other Tor "
+            "in your circuits. Expect hidden services and other Anon "
             "features to be broken in unpredictable ways.\n");
   tor_free(msg);
 
@@ -2309,7 +2309,7 @@ test_options_validate__rend(void *ignored)
   ret = options_validate(NULL, tdata->opt, &msg);
   tt_int_op(ret, OP_EQ, 0);
   expect_log_msg("UseEntryGuards is disabled, but you"
-            " have configured one or more hidden services on this Tor "
+            " have configured one or more hidden services on this Anon "
             "instance.  Your hidden services will be very easy to locate using"
             " a well-known attack -- see https://freehaven.net/anonbib/#hs-"
             "attack06 for details.\n");
@@ -2325,7 +2325,7 @@ test_options_validate__rend(void *ignored)
   ret = options_validate(NULL, tdata->opt, &msg);
   tt_int_op(ret, OP_EQ, 0);
   expect_no_log_msg("UseEntryGuards is disabled, but you"
-            " have configured one or more hidden services on this Tor "
+            " have configured one or more hidden services on this Anon "
             "instance.  Your hidden services will be very easy to locate using"
             " a well-known attack -- see https://freehaven.net/anonbib/#hs-"
             "attack06 for details.\n");
@@ -2944,7 +2944,7 @@ test_options_validate__control(void *ignored)
   expect_log_msg(
             "ControlPort is open, but no authentication method has been "
             "configured.  This means that any program on your computer can "
-            "reconfigure your Tor.  That's bad!  You should upgrade your Tor"
+            "reconfigure your Anon.  That's bad!  You should upgrade your Anon"
             " controller as soon as possible.\n");
   tor_free(msg);
 
@@ -2959,7 +2959,7 @@ test_options_validate__control(void *ignored)
   expect_no_log_msg(
             "ControlPort is open, but no authentication method has been "
             "configured.  This means that any program on your computer can "
-            "reconfigure your Tor.  That's bad!  You should upgrade your Tor "
+            "reconfigure your Anon.  That's bad!  You should upgrade your Anon "
             "controller as soon as possible.\n");
   tor_free(msg);
 
@@ -2975,7 +2975,7 @@ test_options_validate__control(void *ignored)
   expect_no_log_msg(
             "ControlPort is open, but no authentication method has been "
             "configured.  This means that any program on your computer can "
-            "reconfigure your Tor.  That's bad!  You should upgrade your Tor "
+            "reconfigure your Anon.  That's bad!  You should upgrade your Anon "
             "controller as soon as possible.\n");
   tor_free(msg);
 
@@ -2989,7 +2989,7 @@ test_options_validate__control(void *ignored)
   expect_no_log_msg(
             "ControlPort is open, but no authentication method has been "
             "configured.  This means that any program on your computer can "
-            "reconfigure your Tor.  That's bad!  You should upgrade your Tor "
+            "reconfigure your Anon.  That's bad!  You should upgrade your Anon "
             "controller as soon as possible.\n");
   tor_free(msg);
 
@@ -3002,8 +3002,8 @@ test_options_validate__control(void *ignored)
   expect_log_msg(
             "ControlSocket is world writable, but no authentication method has"
             " been configured.  This means that any program on your computer "
-            "can reconfigure your Tor.  That's bad!  You should upgrade your "
-            "Tor controller as soon as possible.\n");
+            "can reconfigure your Anon.  That's bad!  You should upgrade your "
+            "Anon controller as soon as possible.\n");
   tor_free(msg);
 
   free_options_test_data(tdata);
@@ -3017,8 +3017,8 @@ test_options_validate__control(void *ignored)
   expect_no_log_msg(
             "ControlSocket is world writable, but no authentication method has"
             " been configured.  This means that any program on your computer "
-            "can reconfigure your Tor.  That's bad!  You should upgrade your "
-            "Tor controller as soon as possible.\n");
+            "can reconfigure your Anon.  That's bad!  You should upgrade your "
+            "Anon controller as soon as possible.\n");
   tor_free(msg);
 
   free_options_test_data(tdata);
@@ -3033,8 +3033,8 @@ test_options_validate__control(void *ignored)
   expect_no_log_msg(
             "ControlSocket is world writable, but no authentication method has"
             " been configured.  This means that any program on your computer "
-            "can reconfigure your Tor.  That's bad!  You should upgrade your "
-            "Tor controller as soon as possible.\n");
+            "can reconfigure your Anon.  That's bad!  You should upgrade your "
+            "Anon controller as soon as possible.\n");
   tor_free(msg);
 
   free_options_test_data(tdata);
@@ -3047,8 +3047,8 @@ test_options_validate__control(void *ignored)
   expect_no_log_msg(
             "ControlSocket is world writable, but no authentication method has"
             " been configured.  This means that any program on your computer "
-            "can reconfigure your Tor.  That's bad!  You should upgrade your "
-            "Tor controller as soon as possible.\n");
+            "can reconfigure your Anon.  That's bad!  You should upgrade your "
+            "Anon controller as soon as possible.\n");
   tor_free(msg);
 #endif /* defined(HAVE_SYS_UN_H) */
 
@@ -3297,7 +3297,7 @@ test_options_validate__transport(void *ignored)
   ret = options_validate(NULL, tdata->opt, &msg);
   tt_int_op(ret, OP_EQ, 0);
   expect_log_msg(
-            "Tor is not configured as a relay but you specified a "
+            "Anon is not configured as a relay but you specified a "
             "ServerTransportPlugin line (\"foo exec bar\"). The "
             "ServerTransportPlugin line will be ignored.\n");
   tor_free(msg);
@@ -3313,7 +3313,7 @@ test_options_validate__transport(void *ignored)
   ret = options_validate(NULL, tdata->opt, &msg);
   tt_int_op(ret, OP_EQ, 0);
   expect_no_log_msg(
-            "Tor is not configured as a relay but you specified a "
+            "Anon is not configured as a relay but you specified a "
             "ServerTransportPlugin line (\"foo exec bar\"). The "
             "ServerTransportPlugin line will be ignored.\n");
   tor_free(msg);

--- a/src/test/test_options.c
+++ b/src/test/test_options.c
@@ -4167,7 +4167,7 @@ test_options_trial_assign(void *arg)
   tt_int_op(r, OP_EQ, 0);
   v = options_trial_assign(lines, 0, &msg);
   tt_int_op(v, OP_EQ, SETOPT_ERR_TRANSITION);
-  tt_str_op(msg, OP_EQ,  "While Tor is running, changing User is not allowed");
+  tt_str_op(msg, OP_EQ,  "While Anon is running, changing User is not allowed");
   tor_free(msg);
   config_free_lines(lines);
 

--- a/src/test/test_options.c
+++ b/src/test/test_options.c
@@ -1951,7 +1951,7 @@ test_options_validate__testing(void *ignored)
   tdata = get_options_test_data(#varname " " #varval "\n"); \
   ret = options_validate(NULL, tdata->opt, &msg); \
   tt_str_op(msg, OP_EQ, \
-            #varname " may only be changed in testing Tor networks!");  \
+            #varname " may only be changed in testing Anon networks!");  \
   tt_int_op(ret, OP_EQ, -1);                                            \
   tor_free(msg);                                                        \
                                                 \
@@ -1963,7 +1963,7 @@ test_options_validate__testing(void *ignored)
   ret = options_validate(NULL, tdata->opt, &msg);             \
   if (msg) { \
     tt_str_op(msg, OP_NE, \
-              #varname " may only be changed in testing Tor networks!"); \
+              #varname " may only be changed in testing Anon networks!"); \
     tor_free(msg); \
   } \
                                                                         \
@@ -1974,7 +1974,7 @@ test_options_validate__testing(void *ignored)
   ret = options_validate(NULL, tdata->opt, &msg);\
   if (msg) { \
     tt_str_op(msg, OP_NE, \
-              #varname " may only be changed in testing Tor networks!"); \
+              #varname " may only be changed in testing Anon networks!"); \
     tor_free(msg); \
   } \
     STMT_END
@@ -2396,7 +2396,7 @@ test_options_validate__single_onion(void *ignored)
   ret = options_validate(NULL, tdata->opt, &msg);
   tt_int_op(ret, OP_EQ, -1);
   tt_str_op(msg, OP_EQ, "HiddenServiceNonAnonymousMode is incompatible with "
-            "using Tor as an anonymous client. Please set "
+            "using Anon as an anonymous client. Please set "
             "Socks/Trans/NATD/DNSPort to 0, or revert "
             "HiddenServiceNonAnonymousMode to 0.");
   tor_free(msg);
@@ -3797,7 +3797,7 @@ test_options_validate__testing_options(void *ignored)
   ret = options_validate(NULL, tdata->opt, &msg);
   tt_int_op(ret, OP_EQ, -1);
   tt_str_op(msg, OP_EQ, "TestingEnableConnBwEvent may only be changed in "
-            "testing Tor networks!");
+            "testing Anon networks!");
   tor_free(msg);
 
   free_options_test_data(tdata);
@@ -3829,7 +3829,7 @@ test_options_validate__testing_options(void *ignored)
   ret = options_validate(NULL, tdata->opt, &msg);
   tt_int_op(ret, OP_EQ, -1);
   tt_str_op(msg, OP_EQ, "TestingEnableCellStatsEvent may only be changed in "
-            "testing Tor networks!");
+            "testing Anon networks!");
   tor_free(msg);
 
   free_options_test_data(tdata);

--- a/src/test/test_parseconf.sh
+++ b/src/test/test_parseconf.sh
@@ -131,7 +131,7 @@ fi
 
 TOR_BINARY="$(abspath "$TOR_BINARY")"
 
-echo "Using Tor binary '$TOR_BINARY'."
+echo "Using Anon binary '$TOR_BINARY'."
 
 # make a safe space for temporary files
 DATA_DIR=$(mktemp -d -t tor_parseconf_tests.XXXXXX)
@@ -239,7 +239,7 @@ TOR_MODULES_DISABLED="$("$TOR_BINARY" --list-modules | grep ': no' \
 # Remove the last underscore, if there is one
 TOR_MODULES_DISABLED=${TOR_MODULES_DISABLED%_}
 
-echo "Tor is configured with:"
+echo "Anon is configured with:"
 echo "Optional Libraries: ${TOR_LIBS_ENABLED:-(None)}"
 if test "$TOR_LIBS_ENABLED"; then
     echo "Optional Library Search List: $TOR_LIBS_ENABLED_SEARCH"
@@ -258,7 +258,7 @@ log_verify_config()
 {
     # show the command we're about to execute
     # log_verify_config() is only called when we've failed
-    printf "Tor --verify-config said:\\n" >&2
+    printf "Anon --verify-config said:\\n" >&2
     printf "$ %s %s %s %s %s %s %s\\n" \
     "$TOR_BINARY" --verify-config \
                   -f "$1" \
@@ -305,7 +305,7 @@ dump_config()
                        --defaults-anonrc "$2" \
                        $3 \
                        > "$4"; then
-        fail_printf "'%s': Tor --dump-config reported an error%s:\\n%s\\n" \
+        fail_printf "'%s': Anon --dump-config reported an error%s:\\n%s\\n" \
                     "$5" \
                     "$CONTEXT" \
                     "$FULL_TOR_CMD"
@@ -356,7 +356,7 @@ check_diff()
     if cmp "$1" "$2" > /dev/null; then
         return "$TRUE"
     else
-        fail_printf "'%s': Tor --dump-config said%s:\\n%s\\n" \
+        fail_printf "'%s': Anon --dump-config said%s:\\n%s\\n" \
                     "$1" \
                     "$CONTEXT" \
                     "$7"
@@ -459,7 +459,7 @@ verify_config()
 
     # Convert the actual and expected results to boolean, and compare
     if test $((! (! RESULT))) -ne $((! (! $5))); then
-        fail_printf "'%s': Tor --verify-config did not %s:\\n%s\\n" \
+        fail_printf "'%s': Anon --verify-config did not %s:\\n%s\\n" \
                     "$6" \
                     "$7" \
                     "$FULL_TOR_CMD"
@@ -484,7 +484,7 @@ check_pattern()
                     "$3" \
                     "$1" \
                     "$expect_log"
-        printf "Tor --verify-config said:\\n%s\\n" \
+        printf "Anon --verify-config said:\\n%s\\n" \
                "$4" >&2
         cat "$2" >&2
     fi

--- a/src/test/test_rebind.py
+++ b/src/test/test_rebind.py
@@ -37,15 +37,15 @@ def wait_for_log(s):
         l = tor_process.stdout.readline()
         l = l.decode('utf8', 'backslashreplace')
         if s in l:
-            logging.info('Tor logged: "{}"'.format(l.strip()))
+            logging.info('Anon logged: "{}"'.format(l.strip()))
             return
         # readline() returns a blank string when there is no output
         # avoid busy-waiting
         if len(l) == 0:
-            logging.debug('Tor has not logged anything, waiting for "{}"'.format(s))
+            logging.debug('Anon has not logged anything, waiting for "{}"'.format(s))
             time.sleep(LOG_WAIT)
         else:
-            logging.info('Tor logged: "{}", waiting for "{}"'.format(l.strip(), s))
+            logging.info('Anon logged: "{}", waiting for "{}"'.format(l.strip(), s))
     fail('Could not find "{}" in logs after {} seconds'.format(s, LOG_TIMEOUT))
 
 def pick_random_port():
@@ -146,6 +146,6 @@ try:
 except OSError as e:
     if e.errno == errno.ESRCH: # errno 3: No such process
         # assume tor has already exited due to SIGNAL HALT
-        logging.warn("Tor has already exited")
+        logging.warn("Anon has already exited")
     else:
         raise

--- a/src/test/test_socks.c
+++ b/src/test/test_socks.c
@@ -202,7 +202,7 @@ test_socks_4_bad_arguments(void *ptr)
   tt_int_op(fetch_from_buf_socks(buf, socks, 1, 0), OP_EQ, -1);
   buf_clear(buf);
   expect_log_msg_containing("Your application (using socks4 to port 80) "
-                            "gave Tor a malformed hostname: ");
+                            "gave Anon a malformed hostname: ");
   mock_clean_saved_logs();
 
  done:
@@ -742,7 +742,7 @@ test_socks_5_bad_arguments(void *ptr)
   tt_int_op(fetch_from_buf_socks(buf, socks, 1, 0), OP_EQ, -1);
   buf_clear(buf);
   expect_log_msg_containing("Your application (using socks5 to port 80) "
-                            "gave Tor a malformed hostname: ");
+                            "gave Anon a malformed hostname: ");
   mock_clean_saved_logs();
   socks_request_clear(socks);
 

--- a/src/test/test_status.c
+++ b/src/test/test_status.c
@@ -347,7 +347,7 @@ test_status_hb_not_in_consensus(void *arg)
 
   expect_log_msg("Heartbeat: It seems like we are "
                  "not in the cached consensus.\n");
-  expect_log_msg("Heartbeat: Tor's uptime is 0:00 hours, "
+  expect_log_msg("Heartbeat: Anon's uptime is 0:00 hours, "
                  "with 0 circuits open. "
                  "I've sent 0 kB and received 0 kB. "
                  "I've received 0 connections on IPv4 and 0 on IPv6. "
@@ -466,7 +466,7 @@ test_status_hb_simple(void *arg)
 
   tt_int_op(actual, OP_EQ, expected);
 
-  expect_log_msg("Heartbeat: Tor's uptime is 0:00 hours, "
+  expect_log_msg("Heartbeat: Anon's uptime is 0:00 hours, "
                  "with 0 circuits open. "
                  "I've sent 0 kB and received 0 kB. "
                  "I've received 0 connections on IPv4 and 0 on IPv6. "
@@ -588,7 +588,7 @@ test_status_hb_calls_log_accounting(void *arg)
 
   tt_int_op(actual, OP_EQ, expected);
 
-  expect_log_msg("Heartbeat: Tor's uptime is 0:00 hours, "
+  expect_log_msg("Heartbeat: Anon's uptime is 0:00 hours, "
                  "with 0 circuits open. "
                  "I've sent 0 kB and received 0 kB. "
                  "I've received 0 connections on IPv4 and 0 on IPv6. "
@@ -737,7 +737,7 @@ test_status_hb_packaged_cell_fullness(void *arg)
   actual = log_heartbeat(0);
 
   tt_int_op(actual, OP_EQ, expected);
-  expect_log_msg("Heartbeat: Tor's uptime is 0:00 hours, "
+  expect_log_msg("Heartbeat: Anon's uptime is 0:00 hours, "
                  "with 0 circuits open. "
                  "I've sent 0 kB and received 0 kB. "
                  "I've received 0 connections on IPv4 and 0 on IPv6. "
@@ -862,7 +862,7 @@ test_status_hb_tls_write_overhead(void *arg)
   actual = log_heartbeat(0);
 
   tt_int_op(actual, OP_EQ, expected);
-  expect_log_msg("Heartbeat: Tor's uptime is 0:00 hours, "
+  expect_log_msg("Heartbeat: Anon's uptime is 0:00 hours, "
                  "with 0 circuits open. "
                  "I've sent 0 kB and received 0 kB. "
                  "I've received 0 connections on IPv4 and 0 on IPv6. "

--- a/src/tools/anon-resolve.c
+++ b/src/tools/anon-resolve.c
@@ -257,9 +257,9 @@ onion_hs_warning(const char *hostname)
 {
   log_warn(LD_NET,
         "%s is a hidden service; those don't have IP addresses. "
-        "You can use the AutomapHostsOnResolve option to have Tor return a "
+        "You can use the AutomapHostsOnResolve option to have Anon return a "
         "fake address for hidden services.  Or you can have your "
-        "application send the address to Tor directly; we recommend an "
+        "application send the address to Anon directly; we recommend an "
         "application that uses SOCKS 5 with hostnames.",
            hostname);
 }
@@ -578,7 +578,7 @@ main(int argc, char **argv)
     usage();
 
   if (!strcmp(arg[0],"--version")) {
-    printf("Tor version %s.\n",VERSION);
+    printf("Anon version %s.\n",VERSION);
     return 0;
   }
   while (n_args && *arg[0] == '-') {


### PR DESCRIPTION
Upper case name was replaced in:


log_warn
log_notice
log_info
log_fn_ratelim
log_fn
printf
tor_asprintf
tor_assertf
tor_log
log_err
expect_log_msg_containing
expect_log_msg
tor_snprintf
expect_no_log_msg