### PR TITLE
Remove instances of buster build from pipeline

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -88,15 +88,6 @@ jobs:
             suite: bullseye
             arch: arm64
             runner: arm64
-          # Debian Buster
-          - os: debian
-            suite: buster
-            arch: amd64
-            runner: ubuntu-latest
-          - os: debian
-            suite: buster
-            arch: arm64
-            runner: arm64
           # Ubuntu Noble
           - os: ubuntu
             suite: noble

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -218,16 +218,6 @@ debian-disable-relay:
     - ./scripts/ci/ci-driver.sh
 
 #####
-# GPL licensed mode, enables pow module
-debian-gpl:
-  image: debian:buster
-  <<: *debian-template
-  variables:
-    GPL: "yes"
-  script:
-    - ./scripts/ci/ci-driver.sh
-
-#####
 # NSS check on debian
 debian-nss:
   image: debian:bullseye

--- a/debian/misc/backport
+++ b/debian/misc/backport
@@ -37,7 +37,6 @@ squeeze		d6.squeeze	1
 wheezy		d7.wheezy	1
 jessie		d8.jessie	1
 stretch		d9.stretch	1
-buster		d10.buster	1
 bullseye	d11.bullseye	1
 bookworm	d12.bookworm	1
 trixie		d13.trixie	1
@@ -47,7 +46,6 @@ squeeze-bpo	bpo6		1	squeeze-backports
 wheezy-bpo	bpo7		1	wheezy-backports
 jessie-bpo	bpo8		1	jessie-backports
 stretch-bpo	bpo9		1	stretch-backports
-buster-bpo	bpo10		1	buster-backports
 bullseye-bpo	bpo11		1	bullseye-backports
 bookworm-bpo	bpo12		1	bookworm-backports
 trixie-bpo	bpo13		1	trixie-backports

--- a/debian/misc/build-anon-sources
+++ b/debian/misc/build-anon-sources
@@ -148,9 +148,7 @@ backport_all() {
 
 	# buster
 	#################################################
-	bp1 $pkg $dir $sid_debian_version buster
-	(cd $dir; remove_runit)
-	bp2 $pkg $dir $origtar
+	# null
 
 	# bullseye
 	#################################################

--- a/operations/anon-debian-repo.hcl
+++ b/operations/anon-debian-repo.hcl
@@ -170,53 +170,53 @@ fetchers:
       repo: ator-protocol
       assets_regexp: ^anon.+-dev-.+\.deb
       labels:
-        os: 'anon.+(bookworm|bullseye|buster|noble|lunar|jammy|focal).+\.deb'
+        os: 'anon.+(bookworm|bullseye|noble|lunar|jammy|focal).+\.deb'
         arch: '(amd64|arm64)\.deb'
     - name: anon_stage_github_releases
       owner: ATOR-Development
       repo: ator-protocol
       assets_regexp: ^anon.+-stage-.+\.deb
       labels:
-        os: 'anon.+(bookworm|bullseye|buster|noble|lunar|jammy|focal).+\.deb'
+        os: 'anon.+(bookworm|bullseye|noble|lunar|jammy|focal).+\.deb'
         arch: '(amd64|arm64)\.deb'
     - name: anon_beta_github_releases
       owner: ATOR-Development
       repo: ator-protocol
       assets_regexp: ^anon.+-beta-.+\.deb
       labels:
-        os: 'anon.+(bookworm|bullseye|buster|noble|lunar|jammy|focal).+\.deb'
+        os: 'anon.+(bookworm|bullseye|noble|lunar|jammy|focal).+\.deb'
         arch: '(amd64|arm64)\.deb'
     - name: anon_live_github_releases
       owner: ATOR-Development
       repo: ator-protocol
       assets_regexp: ^anon.+-live-.+\.deb
       labels:
-        os: 'anon.+(bookworm|bullseye|buster|noble|lunar|jammy|focal).+\.deb'
+        os: 'anon.+(bookworm|bullseye|noble|lunar|jammy|focal).+\.deb'
         arch: '(amd64|arm64)\.deb'
   nginx_access_log:
     - name: anon_dev_debian_repo
       access_log_path: "/alloc/data/access.log"
       access_log_regexp: '"GET /pool/.+anon_[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+-dev.+\.deb HTTP\/1\.1" 200'
       labels:
-        os: 'anon.+(bookworm|bullseye|buster|noble|lunar|jammy|focal).+\.deb'
+        os: 'anon.+(bookworm|bullseye|noble|lunar|jammy|focal).+\.deb'
         arch: '(amd64|arm64)\.deb'
     - name: anon_stage_debian_repo
       access_log_path: "/alloc/data/access.log"
       access_log_regexp: '"GET /pool/.+anon_[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+-stage.+\.deb HTTP\/1\.1" 200'
       labels:
-        os: 'anon.+(bookworm|bullseye|buster|noble|lunar|jammy|focal).+\.deb'
+        os: 'anon.+(bookworm|bullseye|noble|lunar|jammy|focal).+\.deb'
         arch: '(amd64|arm64)\.deb'
     - name: anon_beta_debian_repo
       access_log_path: "/alloc/data/access.log"
       access_log_regexp: '"GET /pool/.+anon_[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+-beta.+\.deb HTTP\/1\.1" 200'
       labels:
-        os: 'anon.+(bookworm|bullseye|buster|noble|lunar|jammy|focal).+\.deb'
+        os: 'anon.+(bookworm|bullseye|noble|lunar|jammy|focal).+\.deb'
         arch: '(amd64|arm64)\.deb'
     - name: anon_live_debian_repo
       access_log_path: "/alloc/data/access.log"
       access_log_regexp: '"GET /pool/.+anon_[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+-live.+\.deb HTTP\/1\.1" 200'
       labels:
-        os: 'anon.+(bookworm|bullseye|buster|noble|lunar|jammy|focal).+\.deb'
+        os: 'anon.+(bookworm|bullseye|noble|lunar|jammy|focal).+\.deb'
         arch: '(amd64|arm64)\.deb'
         EOH
         destination = "local/exporter.yml"
@@ -309,14 +309,6 @@ SignWith: YES
 
 Origin: Anon
 Label: Anon
-Codename: anon-live-buster
-Architectures: amd64 arm64 source
-Components: main
-Description: Anon Debian Buster Live
-SignWith: YES
-
-Origin: Anon
-Label: Anon
 Codename: anon-live-noble
 Architectures: amd64 arm64 source
 Components: main
@@ -365,14 +357,6 @@ Codename: anon-beta-bullseye
 Architectures: amd64 arm64 source
 Components: main
 Description: Anon Debian Bullseye Beta
-SignWith: YES
-
-Origin: Anon
-Label: Anon
-Codename: anon-beta-buster
-Architectures: amd64 arm64 source
-Components: main
-Description: Anon Debian Buster Beta
 SignWith: YES
 
 Origin: Anon
@@ -429,14 +413,6 @@ SignWith: YES
 
 Origin: Anon
 Label: Anon
-Codename: anon-stage-buster
-Architectures: amd64 arm64 source
-Components: main
-Description: Anon Debian Buster Stage
-SignWith: YES
-
-Origin: Anon
-Label: Anon
 Codename: anon-stage-noble
 Architectures: amd64 arm64 source
 Components: main
@@ -485,14 +461,6 @@ Codename: anon-dev-bullseye
 Architectures: amd64 arm64 source
 Components: main
 Description: Anon Debian Bullseye Dev
-SignWith: YES
-
-Origin: Anon
-Label: Anon
-Codename: anon-dev-buster
-Architectures: amd64 arm64 source
-Components: main
-Description: Anon Debian Buster Dev
 SignWith: YES
 
 Origin: Anon
@@ -549,14 +517,6 @@ SignWith: YES
 
 Origin: Anon
 Label: Anon
-Codename: anon-unstable-dev-buster
-Architectures: amd64 arm64 source
-Components: main
-Description: Anon Debian Buster Unstable Dev
-SignWith: YES
-
-Origin: Anon
-Label: Anon
 Codename: anon-unstable-dev-noble
 Architectures: amd64 arm64 source
 Components: main
@@ -600,7 +560,7 @@ SignWith: YES
 Name: incoming
 IncomingDir: /data/debian/incoming
 TempDir: /tmp
-Allow: anon-live-bookworm anon-live-bullseye anon-live-buster anon-live-noble anon-live-lunar anon-live-jammy anon-live-focal anon-beta-bookworm anon-beta-bullseye anon-beta-buster anon-beta-noble anon-beta-lunar anon-beta-jammy anon-beta-focal anon-stage-bookworm anon-stage-bullseye anon-stage-buster anon-stage-noble anon-stage-lunar anon-stage-jammy anon-stage-focal anon-dev-bookworm anon-dev-bullseye anon-dev-buster anon-dev-noble anon-dev-lunar anon-dev-jammy anon-dev-focal anon-unstable-dev-bookworm anon-unstable-dev-bullseye anon-unstable-dev-buster anon-unstable-dev-noble anon-unstable-dev-lunar anon-unstable-dev-jammy anon-unstable-dev-focal
+Allow: anon-live-bookworm anon-live-bullseye anon-live-noble anon-live-lunar anon-live-jammy anon-live-focal anon-beta-bookworm anon-beta-bullseye anon-beta-noble anon-beta-lunar anon-beta-jammy anon-beta-focal anon-stage-bookworm anon-stage-bullseye anon-stage-noble anon-stage-lunar anon-stage-jammy anon-stage-focal anon-dev-bookworm anon-dev-bullseye anon-dev-noble anon-dev-lunar anon-dev-jammy anon-dev-focal anon-unstable-dev-bookworm anon-unstable-dev-bullseye anon-unstable-dev-noble anon-unstable-dev-lunar anon-unstable-dev-jammy anon-unstable-dev-focal
 Cleanup: on_deny on_error unused_files
         EOH
         destination = "local/incoming"


### PR DESCRIPTION
This PR removes any mention/instances of Buster from the client.

The aim is to eventually remove buster from the Debian package repository.

## Notes
If required another PR must be made to add reprepro commands to delete buster entirely.